### PR TITLE
Node.js 20 - URL fix

### DIFF
--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -32,8 +32,8 @@ export class PatreonOauthClient {
         token?: Token
     ) {
         this.options = {
-            accessTokenUri: 'www.patreon.com/api/oauth2/token',
-            authorizationUri: 'www.patreon.com/oauth2/authorize',
+            accessTokenUri: 'https://www.patreon.com/api/oauth2/token',
+            authorizationUri: 'https://www.patreon.com/oauth2/authorize',
             clientId: options.clientId,
             clientSecret: options.clientSecret,
         }

--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -32,8 +32,8 @@ export class PatreonOauthClient {
         token?: Token
     ) {
         this.options = {
-            accessTokenUri: 'https://www.patreon.com/api/oauth2/token',
-            authorizationUri: 'https://www.patreon.com/oauth2/authorize',
+            accessTokenUri: 'https://patreon.com/api/oauth2/token',
+            authorizationUri: 'https://patreon.com/oauth2/authorize',
             clientId: options.clientId,
             clientSecret: options.clientSecret,
         }


### PR DESCRIPTION
The `URL` object throws an error in Node.js 20, if given a url without the protocol.
This PR adds that to the oauth options.
![image](https://github.com/ghostrider-05/patreon-api.ts/assets/408229/64737873-e901-4372-999c-d83cfd8c3a69)
