### PR TITLE
feat: add rest client

### DIFF
--- a/src/rest/v2/clients/base.ts
+++ b/src/rest/v2/clients/base.ts
@@ -5,19 +5,24 @@ import {
 } from './baseMethods'
 
 import {
-    type Token,
-    type StoredToken,
+    type CreatorToken,
     type PatreonOauthClientOptions,
+    type StoredToken,
+    type Token,
 } from '../oauth2/client'
 
-import { type PatreonTokenFetchOptions } from '../oauth2/store'
+import {
+    type PatreonTokenFetchOptions,
+    type RESTOptions,
+} from '../oauth2'
 import { WebhookClient } from '../webhooks'
 
 export type {
     Oauth2FetchOptions,
     Oauth2RouteOptions,
-    Token,
+    CreatorToken,
     StoredToken,
+    Token,
 }
 
 /**
@@ -35,10 +40,10 @@ export type PatreonClientOptions = {
      */
     name?: string
 
-    rest?: {
-        userAgentAppendix?: string
-        retries?: number
-    }
+    /**
+     * The rest options for this client
+     */
+    rest?: Partial<RESTOptions>
 
     /**
      * Options for storing and getting API (creator) tokens.
@@ -72,8 +77,14 @@ export abstract class BasePatreonClient extends BasePatreonClientMethods {
 
         this.name = patreonOptions.name ?? null
         this.store = patreonOptions.store
+
         this.oauth.onTokenRefreshed = async (token) => {
             if (token) await this.putStoredToken?.(token, true)
+        }
+
+        this.rest.options.getAccessToken = async () => {
+            return await this.fetchStoredToken()
+                .then(token => token?.access_token)
         }
     }
 

--- a/src/rest/v2/clients/base.ts
+++ b/src/rest/v2/clients/base.ts
@@ -1,11 +1,10 @@
 import {
     BasePatreonClientMethods,
-    Oauth2FetchOptions,
-    Oauth2RouteOptions,
+    type Oauth2FetchOptions,
+    type Oauth2RouteOptions,
 } from './baseMethods'
 
 import {
-    PatreonOauthClient,
     type Token,
     type StoredToken,
     type PatreonOauthClientOptions,
@@ -36,6 +35,11 @@ export type PatreonClientOptions = {
      */
     name?: string
 
+    rest?: {
+        userAgentAppendix?: string
+        retries?: number
+    }
+
     /**
      * Options for storing and getting API (creator) tokens.
      * @default undefined
@@ -63,7 +67,7 @@ export abstract class BasePatreonClient extends BasePatreonClientMethods {
     public webhooks: WebhookClient
 
     public constructor(patreonOptions: PatreonClientOptions) {
-        super(new PatreonOauthClient(patreonOptions.oauth))
+        super(patreonOptions.oauth, patreonOptions.rest)
         this.webhooks = new WebhookClient(this.oauth)
 
         this.name = patreonOptions.name ?? null

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -3,10 +3,12 @@ import { Type } from '../../../schemas/v2'
 
 import {
     PatreonOauthClient,
+    type PatreonOauthClientOptions,
     type StoredToken,
 } from '../oauth2/client'
 
 import { Oauth2Routes } from '../oauth2/routes'
+import { RestClient, type RESTOptions } from '../oauth2/rest'
 
 /**
  * Options for the raw Oauth2 request methods
@@ -65,14 +67,21 @@ interface OauthClient {
         path: string,
         query: Query,
         options?: Oauth2FetchOptions,
-    ): AsyncGenerator<GetResponsePayload<Query>, void>
+    ): AsyncGenerator<GetResponsePayload<Query>, number>
 }
 
 export class BasePatreonClientMethods implements OauthClient {
+    public oauth: PatreonOauthClient
+    protected rest: RestClient
+
     public constructor (
-        public oauth: PatreonOauthClient,
+        oauth: PatreonOauthClientOptions,
+        rest: Partial<RESTOptions> = {},
         private _token?: StoredToken,
-    ) {}
+    ) {
+        this.rest = new RestClient(rest)
+        this.oauth = new PatreonOauthClient(oauth, this.rest)
+    }
 
     /**
      * Fetch the Patreon Oauth V2 API
@@ -98,7 +107,7 @@ export class BasePatreonClientMethods implements OauthClient {
         path: string,
         query: Query,
         options?: Oauth2FetchOptions | undefined
-    ): AsyncGenerator<GetResponsePayload<Query>, void, unknown> {
+    ): AsyncGenerator<GetResponsePayload<Query>, number, unknown> {
         if (this._token) {
             options ??= {}
             options.token ??= this._token

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -75,12 +75,12 @@ export class BasePatreonClientMethods implements OauthClient {
     protected rest: RestClient
 
     public constructor (
-        oauth: PatreonOauthClientOptions,
+        protected rawOauthOptions: PatreonOauthClientOptions,
         rest: Partial<RESTOptions> = {},
         private _token?: StoredToken,
     ) {
         this.rest = new RestClient(rest)
-        this.oauth = new PatreonOauthClient(oauth, this.rest)
+        this.oauth = new PatreonOauthClient(rawOauthOptions, this.rest)
     }
 
     /**

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -2,21 +2,29 @@ import type { BasePatreonQuery, BasePatreonQueryType, GetResponsePayload } from 
 import { Type } from '../../../schemas/v2'
 
 import {
+    CreatorToken,
     PatreonOauthClient,
     type PatreonOauthClientOptions,
     type StoredToken,
 } from '../oauth2/client'
 
 import { Oauth2Routes } from '../oauth2/routes'
-import { RestClient, type RESTOptions } from '../oauth2/rest'
+import { RequestMethod, RequestOptions, RestClient, type RESTOptions } from '../oauth2/rest'
+
+type BaseFetchOptions = Omit<RequestOptions,
+    | 'route'
+    | 'accessToken'
+    | 'query'
+>
 
 /**
  * Options for the raw Oauth2 request methods
  */
-export interface Oauth2FetchOptions {
+export interface Oauth2FetchOptions extends BaseFetchOptions {
     /**
      * If an request is missing access on, try to refresh the access token and retry the same request.
      * @default false
+     * @deprecated use `options.rest.retries`
      */
     retryOnFailed?: boolean
 
@@ -26,27 +34,22 @@ export interface Oauth2FetchOptions {
     refreshOnFailed?: boolean
 
     /**
-     * Overwrite the client token with a new token
+     * Overwrite the client token with a new (access) token
      * @default undefined
      */
-    token?: StoredToken
+    token?: StoredToken | CreatorToken | string
 
     /**
      * Overwrite the method of the request.
      * If you are using a function to write, update or delete resources this will be already set.
      * @default 'GET'
      */
-    method?: string
-
-    /**
-     * The stringified body to use in the request, if the endpoint allows a body.
-     * @default undefined
-     */
-    body?: string
+    method?: RequestMethod | `${RequestMethod}`
 
     /**
      * Overwrite the `'Content-Type'` header
      * @default 'application/json'
+     * @deprecated
      */
     contentType?: string
 }

--- a/src/rest/v2/clients/user.ts
+++ b/src/rest/v2/clients/user.ts
@@ -20,7 +20,10 @@ export class PatreonUserClientInstance extends BasePatreonClientMethods {
      */
     public async fetchDiscordId (): Promise<string | undefined> {
         return await this.fetchIdentity(buildQuery.identity(['memberships'])({ user: ['social_connections' ]}))
-            .then(res => res?.data.attributes.social_connections.discord)
+            .then(res => {
+                const option = <{ user_id: string } | null>(res?.data.attributes.social_connections.discord ?? null)
+                return option?.user_id
+        })
     }
 }
 

--- a/src/rest/v2/clients/user.ts
+++ b/src/rest/v2/clients/user.ts
@@ -7,7 +7,7 @@ export class PatreonUserClientInstance extends BasePatreonClientMethods {
     public client: PatreonUserClient
 
     public constructor (client: PatreonUserClient, token: StoredToken) {
-        super(client.oauth, token)
+        super(client['rawOauthOptions'], client['rest'].options, token)
         this.client = client
         this.token = token
     }

--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -1,8 +1,9 @@
-import { If } from '../../../utils/generics'
 import type { Oauth2FetchOptions } from '../clients'
 import { createQuery, type BasePatreonQuery, type GetResponsePayload } from '../query'
 
 import { RestClient, type RestFetcher } from './rest'
+
+import type { If } from '../../../utils/generics'
 
 export interface BaseOauthClientOptions {
     /**

--- a/src/rest/v2/oauth2/index.ts
+++ b/src/rest/v2/oauth2/index.ts
@@ -1,3 +1,17 @@
 export * from './routes'
 export * from './scopes'
 export * from './store'
+
+export {
+    DefaultRestOptions,
+    PATREON_RESPONSE_HEADERS,
+    RequestMethod,
+    type InternalRequestOptions,
+    type PatreonErrorData,
+    type PatreonHeadersData,
+    type RESTOptions,
+    type RequestOptions,
+    type RestFetcher,
+    type RestResponse,
+    type RestRetries
+} from './rest'

--- a/src/rest/v2/oauth2/rest.ts
+++ b/src/rest/v2/oauth2/rest.ts
@@ -1,0 +1,287 @@
+import { VERSION } from "../../../utils"
+import { RouteBases } from "../routes"
+
+type RestResponse = Response
+
+type RestRetries =
+    | number
+    | { status: [number, number] | number, retries: number }[]
+
+export interface RESTOptions {
+    api: string
+    authPrefix: string
+
+    fetch: (url: string, init: RequestInit) => Promise<RestResponse>
+    getAccessToken: () => Promise<string | undefined>
+
+    headers: Record<string, string>
+
+    retries: RestRetries
+    userAgentAppendix: string | undefined
+}
+
+interface RequestOptions {
+    api?: string
+    route?: string
+
+    query?: string
+
+    auth?: boolean
+
+    authPrefix?: string
+    accessToken?: string | undefined
+    body?: string | undefined
+
+    headers?: Record<string, string>
+    timeout?: number
+
+    fetch?: ((url: string, init: RequestInit) => Promise<RestResponse>) | undefined
+    signal?: AbortSignal | undefined
+}
+
+const PATREON_RESPONSE_HEADERS = {
+    Sha: 'x-patreon-sha',
+    UUID: 'x-patreon-uuid',
+} as const
+
+const DefaultRestOptions: RESTOptions = {
+    authPrefix: 'Bearer',
+    api: RouteBases.oauth2,
+    fetch: (...args) => fetch(...args),
+    getAccessToken: async () => undefined,
+    // Set to number for the typecast to be correct
+    retries: 3,
+    headers: {},
+    userAgentAppendix: '',
+}
+
+enum RequestMethod {
+    Get = 'GET',
+    Patch = 'PATCH',
+    Post = 'POST',
+}
+
+type PatreonHeadersData = Record<Lowercase<keyof typeof PATREON_RESPONSE_HEADERS>, string | null>
+
+interface InternalRequestOptions extends RequestOptions {
+    path: string
+    method: RequestMethod
+}
+
+interface PatreonErrorData {
+    id: string
+    code: number
+    code_name: string
+    detail: string
+    status: string
+    title: string
+}
+
+function getRetryAmount (options: RestRetries, status: number | null): number {
+    if (status == null) {
+        return <number>DefaultRestOptions.retries
+    } else if (typeof options === 'number') {
+        return status >= 500 ? options : 0
+    } else {
+        const option = options.find(({ status: optionStatus }) => {
+            return typeof optionStatus === 'number'
+                ? optionStatus === status
+                : optionStatus[0] <= status && optionStatus[1] >= status
+        })
+
+        return option?.retries ?? 0
+    }
+}
+
+async function parseResponse <Parsed = unknown>(response: RestResponse) {
+    return await response.json() as Promise<Parsed>
+}
+
+class PatreonError extends Error implements PatreonErrorData {
+    public id: string
+    public code: number
+    public code_name: string
+    public detail: string
+    public status: string
+    public title: string
+
+    public constructor (
+        error: PatreonErrorData,
+        public data: PatreonHeadersData,
+    ) {
+        super(error.title)
+
+        this.id = error.id
+        this.code = error.code;
+        this.code_name = error.code_name;
+        this.detail = error.detail;
+        this.status = error.status;
+        this.title = error.title;
+    }
+
+    public override get name () {
+        return `${this.code_name}[${this.code}]`
+    }
+}
+
+export class RestClient {
+    public readonly options: RESTOptions;
+
+    public constructor (
+        options: Partial<RESTOptions> = {},
+    ) {
+        this.options = {
+            ...DefaultRestOptions,
+            ...options,
+        }
+
+        // TODO: improve check
+        this.options.fetch ??= DefaultRestOptions.fetch
+        if (this.options.fetch == undefined) {
+            throw new Error('No global fetch function found. Specify options.fetch with your fetch function')
+        }
+    }
+
+    public get userAgent (): string {
+        const userAgentAppendix = VERSION + (this.options.userAgentAppendix?.length ? `, ${this.options.userAgentAppendix}` : '')
+
+        return `PatreonBot patreon-api.ts (https://github.com/ghostrider-05/patreon-api.ts, ${userAgentAppendix})`
+    }
+
+    public async get (path: string, options?: RequestOptions) {
+        return await this.request({ ...options, method: RequestMethod.Get, path })
+    }
+
+    public async patch (path: string, options?: RequestOptions) {
+        return await this.request({ ...options, method: RequestMethod.Patch, path })
+    }
+
+    public async post (path: string, options?: RequestOptions) {
+        return await this.request({ ...options, method: RequestMethod.Post, path })
+    }
+
+    public async request <Parsed = unknown>(options: InternalRequestOptions) {
+        const tryRequest = async (retries = 0): Promise<RestResponse> => {
+            const response = await this.makeRequest({
+                ...options,
+                currentRetries: retries,
+            })
+
+            if (response instanceof Error) {
+                throw response
+            } else if (response == null) {
+                return await tryRequest(++retries)
+            } else {
+                if (response.status === 429) {
+                    // TODO: How should libraries handle 429??
+                    throw new Error('This client is currently ratelimited. Please contact Patreon or reduce your requests')
+                }
+
+                if (response.ok) {
+                    return response
+                } else if (this.shouldRetry(retries, response.status)) {
+                    // Retry with updated access token
+                    if ([401].includes(response.status)) {
+                        const updatedToken = await this.options.getAccessToken()
+
+                        if (updatedToken) options.accessToken = updatedToken
+                    }
+
+                    return await tryRequest(++retries)
+                } else {
+                    // Invalid request, but not retried
+                    const errors = await parseResponse<{ errors: PatreonErrorData[] }>(response)
+
+                    // TODO: can there more than 1 error?
+                    throw new PatreonError(errors.errors[0], this.getHeaders(response))
+                }
+            }
+        }
+
+        return await tryRequest()
+            .then(res => parseResponse<Parsed>(res))
+    }
+
+    private async makeRequest (options: InternalRequestOptions & { currentRetries: number }) {
+        // copied from @discordjs/rest
+        const controller = new AbortController();
+	    const timeout = setTimeout(() => controller.abort(), options.timeout ?? 15_000);
+
+        if (options.signal) {
+            if (options.signal.aborted) controller.abort();
+            else options.signal.addEventListener('abort', () => controller.abort());
+        }
+
+        const fetchAPI = this.buildRequest(options)
+
+        let res: RestResponse;
+
+        try {
+            res = await fetchAPI()
+        } catch (error: unknown) {
+            if (!(error instanceof Error)) throw error;
+
+            if (this.shouldRetry(options.currentRetries, null, error)) {
+                return null
+            }
+
+            return error
+        } finally {
+            clearTimeout(timeout)
+        }
+
+        return res;
+    }
+
+    private buildRequest (options: InternalRequestOptions) {
+        const route = options.route != undefined
+            ? options.route
+            : this.options.api + options.path
+        const url = route + (options.query ?? '')
+
+        const defaultHeaders = {
+            'Content-Type': 'application/json',
+            'User-Agent': this.userAgent,
+        }
+
+        if (options.auth ?? true) {
+            if (!options.accessToken) throw new Error('Missing access token for authenticated request')
+
+            const prefix = (options.authPrefix ?? this.options.authPrefix) + ' '
+            defaultHeaders['Authorization'] = prefix + options.accessToken
+        }
+
+        return async () => await (options.fetch ?? this.options.fetch)(url, {
+            headers: {
+                ...defaultHeaders,
+                ...this.options.headers,
+                ...(options.headers ?? {}),
+            },
+            method: options.method,
+            body: [RequestMethod.Get].includes(options.method)
+                ? options.body ?? null
+                : null,
+            signal: options.signal!,
+        })
+    }
+
+    private shouldRetry (current: number, status: number | null, error?: Error): boolean {
+        const amount = getRetryAmount(this.options.retries, status)
+
+        if (error) {
+            const shouldRetry = error.name === 'AbortError'
+                || (('code' in error && error.code === 'ECONNRESET') || error.message.includes('ECONNRESET'))
+
+            return shouldRetry && amount !== current
+        }
+
+        return amount !== current
+    }
+
+    public getHeaders (response: RestResponse): PatreonHeadersData {
+        return {
+            sha: response.headers.get(PATREON_RESPONSE_HEADERS.Sha),
+            uuid: response.headers.get(PATREON_RESPONSE_HEADERS.UUID),
+        }
+    }
+}

--- a/src/rest/v2/oauth2/rest.ts
+++ b/src/rest/v2/oauth2/rest.ts
@@ -164,11 +164,15 @@ export interface InternalRequestOptions extends RequestOptions {
 
 export interface PatreonErrorData {
     id: string
-    code: number
+    code_challenge: null
+    code: number | null
     code_name: string
     detail: string
     status: string
     title: string
+    source?: {
+        parameter?: string
+    }
 }
 
 function getRetryAmount (options: RestRetries, status: number | null): number {
@@ -193,11 +197,13 @@ async function parseResponse <Parsed = unknown>(response: RestResponse) {
 
 class PatreonError extends Error implements PatreonErrorData {
     public id: string
-    public code: number
+    public code: number | null
     public code_name: string
     public detail: string
     public status: string
     public title: string
+    public code_challenge: null = null
+    public source?: { parameter?: string } = undefined
 
     public constructor (
         error: PatreonErrorData,
@@ -214,7 +220,7 @@ class PatreonError extends Error implements PatreonErrorData {
     }
 
     public override get name () {
-        return `${this.code_name}[${this.code}]`
+        return `${this.code_name}[${this.code ?? 'unkown code'}]`
     }
 }
 

--- a/src/rest/v2/oauth2/store.ts
+++ b/src/rest/v2/oauth2/store.ts
@@ -1,19 +1,9 @@
 import {
     type StoredToken,
 } from './client'
-
-declare class Response {
-    ok: boolean
-    status: number
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    json: () => Promise<any>
-}
-
-export type Fetch = (url: string, options?: {
-    method?: string,
-    headers?: Record<string, string>,
-    body?: string
-}) => Promise<Response>
+import {
+    type RestFetcher,
+} from './rest'
 
 export interface PatreonTokenFetchOptions {
     /**
@@ -43,11 +33,11 @@ class PatreonFetchStore implements PatreonTokenFetchOptions {
      * @param url The server URL that accepts GET and PUT requests
      * @param [fetchFn] The fetch function to use. Defaults to the globally available `fetch` function.
      */
-    public constructor (url: string, fetchFn?: Fetch) {
+    public constructor (url: string, fetchFn?: RestFetcher) {
         const _fetch = fetchFn ?? fetch
 
         this.get = async () => _fetch(url, { method: 'GET' })
-            .then(res => res.ok ? res.json() : undefined)
+            .then(res => res.ok ? res.json() as never : undefined)
 
         this.put = async (token, _url) => {
             await _fetch(_url ?? url, {

--- a/src/schemas/v2/resources/user.ts
+++ b/src/schemas/v2/resources/user.ts
@@ -1,3 +1,29 @@
+// Copied from a /campaigns/id response since no documentation is present
+// TODO: update on new docs
+type RawSocialConnections = { 
+    "discord": {
+        "scopes": string[],
+        "user_id": string
+    },
+    "facebook": null,
+    "google": null,
+    "instagram": null,
+    "reddit": null,
+    "spotify": null,
+    "spotify_open_access": null,
+    "tiktok": null,
+    "twitch": null,
+    "twitter": {
+        "url": string,
+        "user_id": string
+    },
+    "twitter2": null,
+    "vimeo": null,
+    "youtube": null
+}
+
+export type SocialConnectionPlatform = keyof RawSocialConnections
+
 export interface User {
     /**
      * The user's about text, which appears on their profile
@@ -58,8 +84,21 @@ export interface User {
 
     /**
      * Mapping from user's connected app names to external user id on the respective app
+     * 
+     * NOTE: since the documentation is `object`, this can change without notice.
+     * For a more accurate representation use the following type:
+     * ```ts
+     * type SocialConnections = {
+            [P in SocialConnectionPlatform]: (P extends 'discord'
+                ? { scopes: string[], user_id: string }
+                : P extends 'twitter'
+                    ? { url: string, user_id: string }
+                    : string
+            ) | null
+        }
+     * ```
      */
-    social_connections: Record<string, string>
+    social_connections: Record<string, string | null>
 
     /**
      * The user's profile picture URL, scaled to a square of size 100x100px

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -12,6 +12,7 @@ export default defineConfig({
                 // TODO: add tests for clients
                 '**/rest/v2/clients/*.ts',
                 '**/rest/v2/oauth2/client.ts',
+                '**/rest/v2/oauth2/rest.ts',
                 '**/rest/v2/webhooks/client.ts',
             ],
             thresholds: {


### PR DESCRIPTION
<!-- 
Before creating a pull request:
- open an issue
- make sure all the tests (and coverage) pass
- run linter and typescript compiler
 -->

## Changes this PR makes

Changes all requests to a seperate client to improve:
- add more request options: `fetch`, `signal`, `timeout`, `api`, `auth`, `authPrefix` and `headers`
- improve retries on aborted or failed requests with `retries` option instead of `retryOnFailed`. This makes it more customisable how many times a request should be retried.

## Breaking changes

- **BasePatreonClient**: `listOauth2` returns the number of fetched pages
- types: remove `Fetch` and `Response`
- types: add `null` to social_connections

## Bug fixes

- **PatreonUserClientInstance**: correctly return discord id

## Features

- **oauth**: add `validateToken` option
- **oauth**: add `createOauthUri` for creating `oauthUri`
- **oauth**: improve creator token flow

### Deprecations:

- **PatreonOauthClient**: `fetch`, `retryOnFailed`
- **BaseOauthClientOptions**: `fetch`, `retryOnFailed` and `userAgent`
