### PR TITLE
feat: add experimental support for normalized responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can not import this module by API version since it is unlikely that Patreon 
 
 </details>
 
-To read more about how to use this library, go to the [documentation](https://patreon-api.pages.dev). Still doubting if this library has everything you need related to the Patreon API? [Compare all libraries yourself](https://patreon-api.pages.dev/guide/introduction#why).
+To read more about how to use this library, go to the [documentation](https://patreon-api.pages.dev). Still doubting if this library has everything you need related to the Patreon API? [Compare all libraries yourself](https://patreon-api.pages.dev/guide/introduction#comparison).
 
 <details>
 <summary>Compatibility</summary>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![GitHub issues](https://img.shields.io/github/issues/ghostrider-05/patreon-api.ts)](https://github.com/ghostrider-05/patreon-api.ts/issues/)
 [![GitHub stars](https://img.shields.io/github/stars/ghostrider-05/patreon-api.ts?style=flat&label=stargazers)](https://github.com/ghostrider-05/patreon-api.ts/stars/)
 
+<!-- #region introduction -->
+
 Typescript Oauth library for the [V2 Patreon API](https://docs.patreon.com/) with:
 
 - Support for Creator access tokens and Oauth tokens.
@@ -20,6 +22,8 @@ const campaign = await client.fetchCampaign(query)
     // ^? { title: string, id: string, type: Type.Campaign }
 ```
 
+<!-- #endregion introduction -->
+
 ## Installation
 
 ```sh
@@ -33,6 +37,8 @@ yarn add patreon-api.ts
 <details>
 <summary>Supported Patreon api: v2</summary>
 
+<!-- #region api-versions -->
+
 > [!CAUTION]
 > This package does not include v1 of the Patreon API and starts with [API v2](https://docs.patreon.com/#apiv2-oauth)
 
@@ -40,12 +46,16 @@ The default API version for this package is `2` and might change in major versio
 When the default API version is changed, old versions will still receive updates.
 You can not import this module by API version since it is unlikely that Patreon will release a new version any time soon.
 
+<!-- #endregion api-versions -->
+
 </details>
 
 To read more about how to use this library, go to the [documentation](https://patreon-api.pages.dev). Still doubting if this library has everything you need related to the Patreon API? [Compare all libraries yourself](https://patreon-api.pages.dev/guide/introduction#comparison).
 
 <details>
 <summary>Compatibility</summary>
+
+<!-- #region compatibility -->
 
 To check for compatibility with this package, look if your platform:
 
@@ -57,6 +67,8 @@ To check for compatibility with this package, look if your platform:
 
 > [!WARNING]
 > This is a server-side API & Oauth package and requires your application tokens. Make sure you do not share or expose your tokens or run this code client-side.
+
+<!-- #endregion compatibility -->
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,19 @@
 [![GitHub issues](https://img.shields.io/github/issues/ghostrider-05/patreon-api.ts)](https://github.com/ghostrider-05/patreon-api.ts/issues/)
 [![GitHub stars](https://img.shields.io/github/stars/ghostrider-05/patreon-api.ts?style=flat&label=stargazers)](https://github.com/ghostrider-05/patreon-api.ts/stars/)
 
-Typescript library for the [V2 Patreon API](https://docs.patreon.com/) with [Typescript types](./examples/README.md) that strongly reflect your request.
+Typescript Oauth library for the [V2 Patreon API](https://docs.patreon.com/) with:
+
+- Support for Creator access tokens and Oauth tokens.
+- Client with methods for calling every endpoint, both resource and webhook endpoints
+- Methods to create a webhook server
+- Typescript types that strongly reflect your query for raw or normalized responses.
 
 ```ts
-// query: attributes[campaign]=title
-const payload = await client.fetchCampaign(query)
+const query = buildQuery.campaign([])({ campaign: ['title']})
+const payload = await client.api.fetchCampaign(query)
     // ^? { data: { attributes: { title: string } }, ... }
+const campaign = await client.fetchCampaign(query)
+    // ^? { title: string, id: string, type: Type.Campaign }
 ```
 
 ## Installation
@@ -23,6 +30,9 @@ yarn add patreon-api.ts
 
 ## Usage
 
+<details>
+<summary>Supported Patreon api: v2</summary>
+
 > [!CAUTION]
 > This package does not include v1 of the Patreon API and starts with [API v2](https://docs.patreon.com/#apiv2-oauth)
 
@@ -30,11 +40,9 @@ The default API version for this package is `2` and might change in major versio
 When the default API version is changed, old versions will still receive updates.
 You can not import this module by API version since it is unlikely that Patreon will release a new version any time soon.
 
-```ts
-import { type Campaign } from 'patreon-api.ts';
-```
+</details>
 
-While some features are highlighted below, you can read more in the [documentation](https://patreon-api.pages.dev). Still doubting if this library has everything you need related to the Patreon API? [Compare all libraries yourself](https://patreon-api.pages.dev/guide/introduction#why).
+To read more about how to use this library, go to the [documentation](https://patreon-api.pages.dev). Still doubting if this library has everything you need related to the Patreon API? [Compare all libraries yourself](https://patreon-api.pages.dev/guide/introduction#why).
 
 <details>
 <summary>Compatibility</summary>
@@ -52,131 +60,7 @@ To check for compatibility with this package, look if your platform:
 
 </details>
 
-### Clients
-
-#### Creator token
-
-If you don't need to handle Oauth2 requests, but only your own creator profile, the first example will get you started.
-It is recommended to sync your token to your database or store it somewhere safe, so the token is not lost.
-
-<details>
-<summary>Example</summary>
-
-```ts
-import { PatreonCreatorClient, PatreonStore } from 'patreon-api.ts'
-
-const creatorClient = new PatreonCreatorClient({
-    oauth: {
-        clientId: process.env.PATREON_CLIENT_ID!,
-        clientSecret: process.env.PATREON_CLIENT_SECRET!,
-        // Either set the token in the options
-        // or configure a store and call <Client>.initialize()
-        token: {
-            access_token: process.env.PATREON_CREATOR_ACCESS_TOKEN!,
-            refresh_token: process.env.PATREON_CREATOR_REFRESH_TOKEN!,
-        },
-    },
-    store: new PatreonStore.Fetch('<url>'),
-})
-```
-
-</details>
-
-#### User oauth2
-
-For handling Oauth2 requests, add `redirectUri` and if specified a `state` to the options.
-Then fetch the token for the user with request url.
-Note that for handling Oauth2 requests the client will not cache or store the tokens anywhere in case you need to refresh it!
-
-<details>
-<summary>Example</summary>
-
-```ts
-import { PatreonUserClient } from 'patreon-api.ts'
-
-// Minimal configuration for handling Oauth2
-const userClient = new PatreonUserClient({
-    oauth: {
-        clientId: process.env.PATREON_CLIENT_ID!,
-        clientSecret: process.env.PATREON_CLIENT_SECRET!,
-        redirectUri: '<uri>',
-    }
-})
-
-export default {
-    // The Oauth2 callback request with the code parameter
-    fetch: async (request) => {
-        const instance = await userClient.createInstance(request)
-        await instance.fetchIdentity(<query>)
-    }
-}
-```
-
-</details>
-
-### Store
-
-There are 3 built-in methods of retreiving and storing tokens:
-
-1. Manual loading and storing, see the example below
-2. Fetch: use an external server that accepts `GET` and `PUT` requests
-3. KV: store the (creator) token in a KV-like storage system (present on a lot of edge-runtimes).
-
-<details>
-<summary>Example</summary>
-
-```ts
-// Use stored tokens in a database
-// And directly call the `store.get` method on starting the client
-const storeClient = new PatreonCreatorClient({
-    oauth: {
-        clientId: process.env.PATREON_CLIENT_ID!,
-        clientSecret: process.env.PATREON_CLIENT_SECRET!,
-    },
-    name: '<application>', // The application name in the dashboard
-    store: {
-        get: async () => {
-            // Get your stored token
-            return <never>{
-                access_token: '<token>',
-                //...refresh, expires, etc.
-            }
-        },
-        put: async (token) => {
-            console.log(JSON.stringify(token))
-        }
-    }
-})
-```
-
-</details>
-
-### Webhooks
-
-You can interact with the webhooks API using one of the [clients](#clients) above. This library also exposes functions to create a webhook server.
-
-<details>
-<summary>Example</summary>
-
-```ts
-import { parseWebhookRequest } from 'patreon-api.ts'
-
-export default {
-    async fetch (request, env) {
-        const { verified, payload, event } = await parseWebhookRequest(request, env.WEBHOOK_SECRET)
-        if (!verified) return new Response('Invalid request', { status: 403 })
-
-        // handle your event
-    }
-}
-```
-
-</details>
-
 ## Examples
-
-> [!NOTE]
-> In API v2, [all attributes must be explicitly requested](https://docs.patreon.com/#apiv2-oauth).
 
 - [Commonly used routes](./examples/README.md)
 - [Example Cloudflare worker](./examples/cloudflare-webhook/)
@@ -195,3 +79,5 @@ See the [code of conduct](./CODE_OF_CONDUCT.md) and the [contributing guide](./C
 ## License
 
 [MIT](./LICENSE)
+
+Copyright (c) 2023-present, ghostrider-05

--- a/docs/guide/features/index.md
+++ b/docs/guide/features/index.md
@@ -2,7 +2,7 @@
 
 ## Authorization
 
-You can choose between two types of applications:
+The patreon API is only accessible by using Oauth. You can choose between two types of applications:
 
 - [Creator account](./oauth#creator-token)
 - [User Oauth](./oauth#user-oauth2)
@@ -10,6 +10,9 @@ You can choose between two types of applications:
 ## Request
 
 When you have created the application, you're ready to make a request.
+
+> [!NOTE]
+> In API v2, [all attributes must be explicitly requested](https://docs.patreon.com/#apiv2-oauth).
 
 You can use the methods on the client:
 

--- a/docs/guide/features/oauth.md
+++ b/docs/guide/features/oauth.md
@@ -31,6 +31,7 @@ const creatorClient = new PatreonCreatorClient({
 ## User oauth2
 
 For handling Oauth2 requests, add `redirectUri` and if specified a `state` to the options.
+Determine the `scopes` you will need, request only the scopes that your application requires.
 Then fetch the token for the user with request url.
 Note that for handling Oauth2 requests the client will not cache or store the tokens anywhere in case you need to refresh it!
 
@@ -65,7 +66,7 @@ export default {
 
 There are 3 built-in methods of retreiving and storing tokens:
 
-1. Manual loading and storing, see the example below
+1. Manual loading and storing
 2. Fetch: use an external server that accepts `GET` and `PUT` requests
 3. KV: store the (creator) token in a KV-like storage system (present on a lot of edge-runtimes).
 
@@ -90,5 +91,26 @@ const storeClient = new PatreonCreatorClient({
             console.log(JSON.stringify(token))
         }
     }
+})
+```
+
+```ts
+import { PatreonCreatorClient } from 'patreon-api.ts'
+
+interface Env {
+    PATREON_CLIENT_ID: string
+    PATREON_CLIENT_SECRET: string
+    KV_STORE: cf.KVNamespace
+}
+
+// Use stored tokens in a database
+// And directly call the `store.get` method on starting the client
+const storeClient = new PatreonCreatorClient({
+    oauth: {
+        clientId: env.PATREON_CLIENT_ID,
+        clientSecret: env.PATREON_CLIENT_SECRET,
+    },
+    name: '<application>',
+    store: new PatreonStore.KV(env.KV_STORE),
 })
 ```

--- a/docs/guide/features/simplify.md
+++ b/docs/guide/features/simplify.md
@@ -1,7 +1,7 @@
 # Normalized responses
 
 > [!WARNING]
-> This is WIP, see [#26](https://github.com/ghostrider-05/patreon-api.ts/issues/26)
+> This is experimental, see [#26](https://github.com/ghostrider-05/patreon-api.ts/issues/26)
 
 The Patreon API returns data in the [JSON:API]() format with the data spread over `attributes`, `relationships` and `included` fields.
 

--- a/docs/guide/features/simplify.md
+++ b/docs/guide/features/simplify.md
@@ -2,3 +2,22 @@
 
 > [!WARNING]
 > This is WIP, see [#26](https://github.com/ghostrider-05/patreon-api.ts/issues/26)
+
+The Patreon API returns data in the [JSON:API]() format with the data spread over `attributes`, `relationships` and `included` fields.
+
+## normalized
+
+
+## simplified
+
+The `simplify` method will both [normalize](#normalized) the response and convert all keys to camelCase.
+
+```ts
+import { simplify } from 'patreon-api.ts'
+
+const query = buildQuery.campaign(['creator'])({ creator: ['full_name'], campaign: ['created_at' ]})
+const rawCampaign = await <Client>.fetchCampaign('campaign_id', query)
+
+const campaign = simplify(rawCampaign)
+console.log(`Campaign by ${campaign.creator.fullName} created at ${campaign.createdAt}`)
+```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,9 +18,11 @@ features:
 
 ## Platform
 
-<!-- @include: ../../README.md{41,51} -->
+<!-- @include: ../../README.md{50,59} -->
 
 ## Set up
+
+This package exports both CJS and ESM code. However, the guide will only have ESM examples.
 
 ::: code-group
 
@@ -38,7 +40,7 @@ yarn add patreon-api.ts
 
 :::
 
-<!-- @include: ../../README.md{26,35} -->
+<!-- @include: ../../README.md{35,42} -->
 
 To get started you can see one of the examples:
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,7 +18,7 @@ features:
 
 ## Platform
 
-<!-- @include: ../../README.md{50,59} -->
+<!-- @include: ../../README.md#compatibility -->
 
 ## Set up
 
@@ -40,7 +40,7 @@ yarn add patreon-api.ts
 
 :::
 
-<!-- @include: ../../README.md{35,42} -->
+<!-- @include: ../../README.md#api-versions -->
 
 To get started you can see one of the examples:
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -136,13 +136,11 @@ keys:
 
 # Introduction
 
-> {{ site.description }}
+<!-- @include:../../README.md{8,21} -->
 
-<!-- @include:../../README.md{9,14} -->
+## Comparison
 
-## Why
-
-See why I made this library with all[*](#search-filter) [JavaScript and TypeScript repositories for the Patreon API](https://github.com/search?q=patreon+language:JavaScript+language:TypeScript++archived:false++is:public+stars:%3E0&type=repositories&s=stars&o=desc) compared (scroll to see all features):
+See why I made this library with all* [JavaScript and TypeScript repositories for the Patreon API](https://github.com/search?q=patreon+language:JavaScript+language:TypeScript++archived:false++is:public+stars:%3E0&type=repositories&s=stars&o=desc) compared (scroll to see all features):
 
 <LibraryTable />
 
@@ -165,7 +163,4 @@ If a library has been updated or a new library has met the requirements above, i
 
 <script setup>
 import LibraryTable from '../.vitepress/components/LibraryTable.vue'
-import { useData } from 'vitepress'
-
-const { site } = useData()
 </script>

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -136,7 +136,7 @@ keys:
 
 # Introduction
 
-<!-- @include:../../README.md{8,21} -->
+<!-- @include:../../README.md#introduction -->
 
 ## Comparison
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -7,7 +7,7 @@ libraries:
       user: true
       creator: true
       webhooks: true
-      simplified: false
+      simplified: true
       raw: true
       fetch_patrons: true
       fetch_identity: true
@@ -146,7 +146,7 @@ See why I made this library with all[*](#search-filter) [JavaScript and TypeScri
 
 <LibraryTable />
 
-### Search filter
+:::details Repository requirements
 
 A library is included if it:
 
@@ -156,6 +156,8 @@ A library is included if it:
   - **not** for scraping, only related to badges, downloading assets or a Patreon clone
   - exports code or is published on NPM
 - is not archived
+
+:::
 
 ### Contributions
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "@patreon-api.ts/docs",
       "devDependencies": {
-        "@vueuse/core": "^10.11.0",
-        "vitepress": "^1.3.0",
-        "vue": "^3.4.31",
-        "vuetify": "^3.6.11"
+        "@vueuse/core": "^11.0.3",
+        "vitepress": "^1.3.4",
+        "vue": "^3.5.3",
+        "vuetify": "^3.7.1"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -92,6 +92,27 @@
         "@algolia/transporter": "4.24.0"
       }
     },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
     "node_modules/@algolia/client-analytics": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
@@ -104,7 +125,7 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/client-common": {
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
       "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
@@ -112,6 +133,27 @@
       "dependencies": {
         "@algolia/requester-common": "4.24.0",
         "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.3.0.tgz",
+      "integrity": "sha512-iGx2c9aI8ZiGD512WUIu36hrG0XtJOBWseI+w7DyQpfDcG9u9Go9/9jkJZRXWzfrCqlMWyXMQ8z5N4vKTAhZ6g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
@@ -125,15 +167,29 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/client-search": {
+    "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
       "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
         "@algolia/requester-common": "4.24.0",
         "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.3.0.tgz",
+      "integrity": "sha512-k4MWhi6j2YhvwKqyLmk6AKr1Vts/HDmbfjmzyd2/j72ftRHQ/nHWwsvoSyrTBu39yv3loNduBAXu58vw0JFJsQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.3.0",
+        "@algolia/requester-browser-xhr": "5.3.0",
+        "@algolia/requester-node-http": "5.3.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/logger-common": {
@@ -170,13 +226,56 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/requester-browser-xhr": {
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
       "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
       "dev": true,
       "dependencies": {
         "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.3.0.tgz",
+      "integrity": "sha512-+lPsyrV8xmwyN3O4jFDvyiXph4S6Xa3r0DSzT0GLKnHGm6vHa81f5URruk6wYh1OVCn1H6MDMrawjKF4fY11qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.3.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-common": {
@@ -186,12 +285,16 @@
       "dev": true
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.3.0.tgz",
+      "integrity": "sha512-e9aWqwOJAnIS366iq0NFut3RCJutaqs8Gb0z9MQIgg6M/zg38jE0+Xgz6RscN0wPazRODpvPjkpKgsDHjftyUw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "@algolia/requester-common": "4.24.0"
+        "@algolia/client-common": "5.3.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/transporter": {
@@ -205,11 +308,32 @@
         "@algolia/requester-common": "4.24.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.25.6"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -217,31 +341,45 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/types": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@docsearch/css": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
-      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.1.tgz",
+      "integrity": "sha512-VtVb5DS+0hRIprU2CO6ZQjK2Zg4QU5HrDM1+ix6rT0umsYvFvatMAnf97NHZlVWDaaLlx7GRfR/7FikANiM2Fg==",
       "dev": true
     },
     "node_modules/@docsearch/js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.0.tgz",
-      "integrity": "sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.1.tgz",
+      "integrity": "sha512-erI3RRZurDr1xES5hvYJ3Imp7jtrXj6f1xYIzDzxiS7nNBufYWPbJwrmMqWC5g9y165PmxEmN9pklGCdLi0Iqg==",
       "dev": true,
       "dependencies": {
-        "@docsearch/react": "3.6.0",
+        "@docsearch/react": "3.6.1",
         "preact": "^10.0.0"
       }
     },
     "node_modules/@docsearch/react": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
-      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.1.tgz",
+      "integrity": "sha512-qXZkEPvybVhSXj0K7U3bXc233tk5e8PfhoZ6MhPOiik/qUQxYC+Dn9DnoS7CxHQQhHfCvTiN0eY9M12oRghEXw==",
       "dev": true,
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.6.0",
+        "@docsearch/css": "3.6.1",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -634,15 +772,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+      "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
       "cpu": [
         "arm"
       ],
@@ -653,9 +791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+      "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
       "cpu": [
         "arm64"
       ],
@@ -666,9 +804,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+      "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
       "cpu": [
         "arm64"
       ],
@@ -679,9 +817,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+      "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+      "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
       "cpu": [
         "arm"
       ],
@@ -705,9 +843,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+      "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
       "cpu": [
         "arm"
       ],
@@ -718,9 +856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+      "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
       "cpu": [
         "arm64"
       ],
@@ -731,9 +869,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+      "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
       "cpu": [
         "arm64"
       ],
@@ -744,9 +882,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+      "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
       "cpu": [
         "ppc64"
       ],
@@ -757,9 +895,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+      "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
       "cpu": [
         "riscv64"
       ],
@@ -770,9 +908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+      "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
       "cpu": [
         "s390x"
       ],
@@ -783,9 +921,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+      "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
       "cpu": [
         "x64"
       ],
@@ -796,9 +934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+      "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
       "cpu": [
         "x64"
       ],
@@ -809,9 +947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+      "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
       "cpu": [
         "arm64"
       ],
@@ -822,9 +960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+      "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
       "cpu": [
         "ia32"
       ],
@@ -835,9 +973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+      "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
       "cpu": [
         "x64"
       ],
@@ -848,22 +986,29 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.3.tgz",
-      "integrity": "sha512-D45PMaBaeDHxww+EkcDQtDAtzv00Gcsp72ukBtaLSmqRvh0WgGMq3Al0rl1QQBZfuneO75NXMIzEZGFitThWbg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.16.2.tgz",
+      "integrity": "sha512-XSVH5OZCvE4WLMgdoBqfPMYmGHGmCC3OgZhw0S7KcSi2XKZ+5oHGe71GFnTljgdOxvxx5WrRks6QoTLKrl1eAA==",
       "dev": true,
       "dependencies": {
+        "@shikijs/vscode-textmate": "^9.2.0",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.10.3.tgz",
-      "integrity": "sha512-MNjsyye2WHVdxfZUSr5frS97sLGe6G1T+1P41QjyBFJehZphMcr4aBlRLmq6OSPBslYe9byQPVvt/LJCOfxw8Q==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.16.2.tgz",
+      "integrity": "sha512-AR6ANiKwi1dJr5g/W0L+Su4PoHurkHLgtNmesbOFOPGKNQC2BeGU/Z2Ghkl+cUF5PfE+UeLkxUwzpE6H37hTSg==",
       "dev": true,
       "dependencies": {
-        "shiki": "1.10.3"
+        "shiki": "1.16.2"
       }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.0.tgz",
+      "integrity": "sha512-5FinaOp6Vdh/dl4/yaOTh0ZeKch+rYS8DUb38V3GMKYVkdqzxw53lViRKUYkVILRiVQT7dcPC7VvAKOR73zVtQ==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -887,9 +1032,9 @@
       "dev": true
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -902,41 +1047,10 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@types/unist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
-      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "node_modules/@types/web-bluetooth": {
@@ -946,9 +1060,9 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.5.tgz",
-      "integrity": "sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.3.tgz",
+      "integrity": "sha512-3xbWsKEKXYlmX82aOHufFQVnkbMC/v8fLpWwh6hWOUrK5fbbtBh9Q/WWse27BFgSy2/e2c0fz5Scgya9h2GLhw==",
       "dev": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -959,71 +1073,71 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.31.tgz",
-      "integrity": "sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.3.tgz",
+      "integrity": "sha512-adAfy9boPkP233NTyvLbGEqVuIfK/R0ZsBsIOW4BZNfb4BRpRW41Do1u+ozJpsb+mdoy80O20IzAsHaihRb5qA==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/shared": "3.4.31",
+        "@babel/parser": "^7.25.3",
+        "@vue/shared": "3.5.3",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz",
-      "integrity": "sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.3.tgz",
+      "integrity": "sha512-wnzFArg9zpvk/811CDOZOadJRugf1Bgl/TQ3RfV4nKfSPok4hi0w10ziYUQR6LnnBAUlEXYLUfZ71Oj9ds/+QA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/compiler-core": "3.5.3",
+        "@vue/shared": "3.5.3"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.31.tgz",
-      "integrity": "sha512-einJxqEw8IIJxzmnxmJBuK2usI+lJonl53foq+9etB2HAzlPjAS/wa7r0uUpXw5ByX3/0uswVSrjNb17vJm1kQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.3.tgz",
+      "integrity": "sha512-P3uATLny2tfyvMB04OQFe7Sczteno7SLFxwrOA/dw01pBWQHB5HL15a8PosoNX2aG/EAMGqnXTu+1LnmzFhpTQ==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/compiler-core": "3.4.31",
-        "@vue/compiler-dom": "3.4.31",
-        "@vue/compiler-ssr": "3.4.31",
-        "@vue/shared": "3.4.31",
+        "@babel/parser": "^7.25.3",
+        "@vue/compiler-core": "3.5.3",
+        "@vue/compiler-dom": "3.5.3",
+        "@vue/compiler-ssr": "3.5.3",
+        "@vue/shared": "3.5.3",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.10",
-        "postcss": "^8.4.38",
+        "magic-string": "^0.30.11",
+        "postcss": "^8.4.44",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.31.tgz",
-      "integrity": "sha512-RtefmITAje3fJ8FSg1gwgDhdKhZVntIVbwupdyZDSifZTRMiWxWehAOTCc8/KZDnBOcYQ4/9VWxsTbd3wT0hAA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.3.tgz",
+      "integrity": "sha512-F/5f+r2WzL/2YAPl7UlKcJWHrvoZN8XwEBLnT7S4BXwncH25iDOabhO2M2DWioyTguJAGavDOawejkFXj8EM1w==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/compiler-dom": "3.5.3",
+        "@vue/shared": "3.5.3"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.3.5.tgz",
-      "integrity": "sha512-BSdBBu5hOIv+gBJC9jzYMh5bC27FQwjWLSb8fVAniqlL9gvsqvK27xTgczMf+hgctlszMYQnRm3bpY/j8vhPqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.4.4.tgz",
+      "integrity": "sha512-Iqqy9yBFWBbPb/jHlJzU/OrU+iHSJ/e9p/v5pZhm/L5pUCX26z32bvvjPa28vMXxRehbAZTgX8zovOeqBTnhdg==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-kit": "^7.3.5"
+        "@vue/devtools-kit": "^7.4.4"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.3.5.tgz",
-      "integrity": "sha512-wwfi10gJ1HMtjzcd8aIOnzBHlIRqsYDgcDyrKvkeyc0Gbcoe7UrkXRVHZUOtcxxoplHA0PwpT6wFg0uUCmi8Ww==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.4.4.tgz",
+      "integrity": "sha512-awK/4NfsUG0nQ7qnTM37m7ZkEUMREyPh8taFCX+uQYps/MTFEum0AD05VeGDRMXwWvMmGIcWX9xp8ZiBddY0jw==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-shared": "^7.3.5",
+        "@vue/devtools-shared": "^7.4.4",
         "birpc": "^0.2.17",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
@@ -1033,83 +1147,83 @@
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.3.5.tgz",
-      "integrity": "sha512-Rqii3VazmWTi67a86rYopi61n5Ved05EybJCwyrfoO9Ok3MaS/4yRFl706ouoISMlyrASJFEzM0/AiDA6w4f9A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.4.4.tgz",
+      "integrity": "sha512-yeJULXFHOKIm8yL2JFO050a9ztTVqOCKTqN9JHFxGTJN0b+gjtfn6zC+FfyHUgjwCwf6E3hfKrlohtthcqoYqw==",
       "dev": true,
       "dependencies": {
         "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.31.tgz",
-      "integrity": "sha512-VGkTani8SOoVkZNds1PfJ/T1SlAIOf8E58PGAhIOUDYPC4GAmFA2u/E14TDAFcf3vVDKunc4QqCe/SHr8xC65Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.3.tgz",
+      "integrity": "sha512-2w61UnRWTP7+rj1H/j6FH706gRBHdFVpIqEkSDAyIpafBXYH8xt4gttstbbCWdU3OlcSWO8/3mbKl/93/HSMpw==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.4.31"
+        "@vue/shared": "3.5.3"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.31.tgz",
-      "integrity": "sha512-LDkztxeUPazxG/p8c5JDDKPfkCDBkkiNLVNf7XZIUnJ+66GVGkP+TIh34+8LtPisZ+HMWl2zqhIw0xN5MwU1cw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.3.tgz",
+      "integrity": "sha512-5b2AQw5OZlmCzSsSBWYoZOsy75N4UdMWenTfDdI5bAzXnuVR7iR8Q4AOzQm2OGoA41xjk53VQKrqQhOz2ktWaw==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/reactivity": "3.5.3",
+        "@vue/shared": "3.5.3"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.31.tgz",
-      "integrity": "sha512-2Auws3mB7+lHhTFCg8E9ZWopA6Q6L455EcU7bzcQ4x6Dn4cCPuqj6S2oBZgN2a8vJRS/LSYYxwFFq2Hlx3Fsaw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.3.tgz",
+      "integrity": "sha512-wPR1DEGc3XnQ7yHbmkTt3GoY0cEnVGQnARRdAkDzZ8MbUKEs26gogCQo6AOvvgahfjIcnvWJzkZArQ1fmWjcSg==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.31",
-        "@vue/runtime-core": "3.4.31",
-        "@vue/shared": "3.4.31",
+        "@vue/reactivity": "3.5.3",
+        "@vue/runtime-core": "3.5.3",
+        "@vue/shared": "3.5.3",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.31.tgz",
-      "integrity": "sha512-D5BLbdvrlR9PE3by9GaUp1gQXlCNadIZytMIb8H2h3FMWJd4oUfkUTEH2wAr3qxoRz25uxbTcbqd3WKlm9EHQA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.3.tgz",
+      "integrity": "sha512-28volmaZVG2PGO3V3+gBPKoSHvLlE8FGfG/GKXKkjjfxLuj/50B/0OQGakM/g6ehQeqCrZYM4eHC4Ks48eig1Q==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/compiler-ssr": "3.5.3",
+        "@vue/shared": "3.5.3"
       },
       "peerDependencies": {
-        "vue": "3.4.31"
+        "vue": "3.5.3"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
-      "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.3.tgz",
+      "integrity": "sha512-Jp2v8nylKBT+PlOUjun2Wp/f++TfJVFjshLzNtJDdmFJabJa7noGMncqXRM1vXGX+Yo2V7WykQFNxusSim8SCA==",
       "dev": true
     },
     "node_modules/@vueuse/core": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.0.tgz",
-      "integrity": "sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.0.3.tgz",
+      "integrity": "sha512-RENlh64+SYA9XMExmmH1a3TPqeIuJBNNB/63GT35MZI+zpru3oMRUA6cEFr9HmGqEgUisurwGwnIieF6qu3aXw==",
       "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.11.0",
-        "@vueuse/shared": "10.11.0",
-        "vue-demi": ">=0.14.8"
+        "@vueuse/metadata": "11.0.3",
+        "@vueuse/shared": "11.0.3",
+        "vue-demi": ">=0.14.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1133,14 +1247,14 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.11.0.tgz",
-      "integrity": "sha512-Pp6MtWEIr+NDOccWd8j59Kpjy5YDXogXI61Kb1JxvSfVBO8NzFQkmrKmSZz47i+ZqHnIzxaT38L358yDHTncZg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.0.3.tgz",
+      "integrity": "sha512-w6CDisaxs19S5Fd+NPPLFaA3GoX5gxuxrbTTBu0EYap7oH13w75L6C/+7e9mcoF9akhcR6GyYajwVMQEjdapJg==",
       "dev": true,
       "dependencies": {
-        "@vueuse/core": "10.11.0",
-        "@vueuse/shared": "10.11.0",
-        "vue-demi": ">=0.14.8"
+        "@vueuse/core": "11.0.3",
+        "@vueuse/shared": "11.0.3",
+        "vue-demi": ">=0.14.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1148,16 +1262,16 @@
       "peerDependencies": {
         "async-validator": "^4",
         "axios": "^1",
-        "change-case": "^4",
-        "drauu": "^0.3",
+        "change-case": "^5",
+        "drauu": "^0.4",
         "focus-trap": "^7",
-        "fuse.js": "^6",
+        "fuse.js": "^7",
         "idb-keyval": "^6",
-        "jwt-decode": "^3",
+        "jwt-decode": "^4",
         "nprogress": "^0.2",
         "qrcode": "^1.5",
         "sortablejs": "^1",
-        "universal-cookie": "^6"
+        "universal-cookie": "^7"
       },
       "peerDependenciesMeta": {
         "async-validator": {
@@ -1199,9 +1313,9 @@
       }
     },
     "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1225,30 +1339,30 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
-      "integrity": "sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.0.3.tgz",
+      "integrity": "sha512-+FtbO4SD5WpsOcQTcC0hAhNlOid6QNLzqedtquTtQ+CRNBoAt9GuV07c6KNHK1wCmlq8DFPwgiLF2rXwgSHX5Q==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
-      "integrity": "sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.0.3.tgz",
+      "integrity": "sha512-0rY2m6HS5t27n/Vp5cTDsKTlNnimCqsbh/fmT2LgE+aaU42EMfXo8+bNX91W9I7DDmxfuACXMmrd7d79JxkqWA==",
       "dev": true,
       "dependencies": {
-        "vue-demi": ">=0.14.8"
+        "vue-demi": ">=0.14.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1292,6 +1406,45 @@
         "@algolia/requester-common": "4.24.0",
         "@algolia/requester-node-http": "4.24.0",
         "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/birpc": {
@@ -1421,43 +1574,13 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/mark.js": {
@@ -1467,9 +1590,9 @@
       "dev": true
     },
     "node_modules/minisearch": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
-      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.0.tgz",
+      "integrity": "sha512-tv7c/uefWdEhcu6hvrfTihflgeEi2tN6VV7HJnCjK6VxM75QQJh4t9FwJCsA2EsRS8LCnu3W87CuGPWMocOLCA==",
       "dev": true
     },
     "node_modules/mitt": {
@@ -1509,9 +1632,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+      "version": "8.4.45",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
+      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
       "dev": true,
       "funding": [
         {
@@ -1537,42 +1660,13 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.22.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.0.tgz",
-      "integrity": "sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==",
+      "version": "10.23.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
+      "integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "node_modules/rfdc": {
@@ -1582,9 +1676,9 @@
       "dev": true
     },
     "node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+      "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -1597,50 +1691,40 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "@rollup/rollup-android-arm-eabi": "4.21.2",
+        "@rollup/rollup-android-arm64": "4.21.2",
+        "@rollup/rollup-darwin-arm64": "4.21.2",
+        "@rollup/rollup-darwin-x64": "4.21.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.21.2",
+        "@rollup/rollup-linux-arm64-musl": "4.21.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-musl": "4.21.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.21.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.21.2",
+        "@rollup/rollup-win32-x64-msvc": "4.21.2",
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/search-insights": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
-      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.1.tgz",
+      "integrity": "sha512-HHFjYH/0AqXacETlIbe9EYc3UNlQYGNNTY0fZ/sWl6SweX+GDxq9NB5+RVoPLgEFuOtCz7M9dhYxqDnhbbF0eQ==",
       "dev": true,
       "peer": true
     },
     "node_modules/shiki": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.3.tgz",
-      "integrity": "sha512-eneCLncGuvPdTutJuLyUGS8QNPAVFO5Trvld2wgEq1e002mwctAhJKeMGWtWVXOIEzmlcLRqcgPSorR6AVzOmQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.16.2.tgz",
+      "integrity": "sha512-gSym0hZf5a1U0iDPsdoOAZbvoi+e0c6c3NKAi03FoSLTm7oG20tum29+gk0wzzivOasn3loxfGUPT+jZXIUbWg==",
       "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.10.3",
+        "@shikijs/core": "1.16.2",
+        "@shikijs/vscode-textmate": "^9.2.0",
         "@types/hast": "^3.0.4"
       }
     },
@@ -1680,23 +1764,24 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "dev": true
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/vite": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
-      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
+      "integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1715,6 +1800,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -1732,6 +1818,9 @@
         "sass": {
           "optional": true
         },
+        "sass-embedded": {
+          "optional": true
+        },
         "stylus": {
           "optional": true
         },
@@ -1744,27 +1833,27 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.3.0.tgz",
-      "integrity": "sha512-Cbm2AgXcCrukUeV+/24g1ZDSvw8blamh/1uf2pz3ApFpaYb9T7mo4imWDZ6APn2uPo4bJ6sgOzvsJ4aH+oLbBA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.3.4.tgz",
+      "integrity": "sha512-I1/F6OW1xl3kW4PaIMC6snxjWgf3qfziq2aqsDoFc/Gt41WbcRv++z8zjw8qGRIJ+I4bUW7ZcKFDHHN/jkH9DQ==",
       "dev": true,
       "dependencies": {
-        "@docsearch/css": "^3.6.0",
-        "@docsearch/js": "^3.6.0",
-        "@shikijs/core": "^1.10.3",
-        "@shikijs/transformers": "^1.10.3",
-        "@types/markdown-it": "^14.1.1",
-        "@vitejs/plugin-vue": "^5.0.5",
-        "@vue/devtools-api": "^7.3.5",
-        "@vue/shared": "^3.4.31",
-        "@vueuse/core": "^10.11.0",
-        "@vueuse/integrations": "^10.11.0",
+        "@docsearch/css": "^3.6.1",
+        "@docsearch/js": "^3.6.1",
+        "@shikijs/core": "^1.13.0",
+        "@shikijs/transformers": "^1.13.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.1.2",
+        "@vue/devtools-api": "^7.3.8",
+        "@vue/shared": "^3.4.38",
+        "@vueuse/core": "^11.0.0",
+        "@vueuse/integrations": "^11.0.0",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
-        "minisearch": "^6.3.0",
-        "shiki": "^1.10.3",
-        "vite": "^5.3.3",
-        "vue": "^3.4.31"
+        "minisearch": "^7.1.0",
+        "shiki": "^1.13.0",
+        "vite": "^5.4.1",
+        "vue": "^3.4.38"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
@@ -1783,16 +1872,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.31.tgz",
-      "integrity": "sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.3.tgz",
+      "integrity": "sha512-xvRbd0HpuLovYbOHXRHlSBsSvmUJbo0pzbkKTApWnQGf3/cu5Z39mQeA5cZdLRVIoNf3zI6MSoOgHUT5i2jO+Q==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.31",
-        "@vue/compiler-sfc": "3.4.31",
-        "@vue/runtime-dom": "3.4.31",
-        "@vue/server-renderer": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/compiler-dom": "3.5.3",
+        "@vue/compiler-sfc": "3.5.3",
+        "@vue/runtime-dom": "3.5.3",
+        "@vue/server-renderer": "3.5.3",
+        "@vue/shared": "3.5.3"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -1804,9 +1893,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.11.tgz",
-      "integrity": "sha512-DMreVZ6+WCVnvRoFVPGtC+Kc4afx+etcTLgX2AqUj6lQ4RrEx0TlQoNAW1oKPH4eViv2wfdvQ3xb/Yw1c86cTw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.1.tgz",
+      "integrity": "sha512-N1XlczbgeGt/O+JUk72QPrqcDaRIXUdptUciJqGyTvZ9cfMoSlEWs6TZO+dOOfXbKvmIMFMycYg4dgSHDpCPhg==",
       "dev": true,
       "engines": {
         "node": "^12.20 || >=14.13"
@@ -1819,7 +1908,6 @@
         "typescript": ">=4.7",
         "vite-plugin-vuetify": ">=1.0.0",
         "vue": "^3.3.0",
-        "vue-i18n": "^9.0.0",
         "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
@@ -1827,9 +1915,6 @@
           "optional": true
         },
         "vite-plugin-vuetify": {
-          "optional": true
-        },
-        "vue-i18n": {
           "optional": true
         },
         "webpack-plugin-vuetify": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,9 +7,9 @@
       "name": "@patreon-api.ts/docs",
       "devDependencies": {
         "@vueuse/core": "^10.11.0",
-        "vitepress": "^1.2.3",
+        "vitepress": "^1.3.0",
         "vue": "^3.4.31",
-        "vuetify": "^3.6.10"
+        "vuetify": "^3.6.11"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -848,18 +848,21 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-EmUful2MQtY8KgCF1OkBtOuMcvaZEvmdubhW0UHCGXi21O9dRLeADVCj+k6ZS+de7Mz9d2qixOXJ+GLhcK3pXg==",
-      "dev": true
-    },
-    "node_modules/@shikijs/transformers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.9.1.tgz",
-      "integrity": "sha512-wPrGTpBURQ95IKPIhPQE3bGsANpPPtea1+aVHZp0aYtgxfL5UM3QbJ5rNdCuhcyjz/JNp5ZvSItOr+ayJxebJQ==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.3.tgz",
+      "integrity": "sha512-D45PMaBaeDHxww+EkcDQtDAtzv00Gcsp72ukBtaLSmqRvh0WgGMq3Al0rl1QQBZfuneO75NXMIzEZGFitThWbg==",
       "dev": true,
       "dependencies": {
-        "shiki": "1.9.1"
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.10.3.tgz",
+      "integrity": "sha512-MNjsyye2WHVdxfZUSr5frS97sLGe6G1T+1P41QjyBFJehZphMcr4aBlRLmq6OSPBslYe9byQPVvt/LJCOfxw8Q==",
+      "dev": true,
+      "dependencies": {
+        "shiki": "1.10.3"
       }
     },
     "node_modules/@types/estree": {
@@ -867,6 +870,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -920,6 +932,12 @@
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
+      "dev": true
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
@@ -991,21 +1009,21 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.3.4.tgz",
-      "integrity": "sha512-E5dJlLW+NgGb+WS33y99ioOJL2OXpVhje6VwXGJ/q5fNizJDpe67Ml0GBSrlYOKNSjZs2mwcZd7B3e12th3Q0g==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.3.5.tgz",
+      "integrity": "sha512-BSdBBu5hOIv+gBJC9jzYMh5bC27FQwjWLSb8fVAniqlL9gvsqvK27xTgczMf+hgctlszMYQnRm3bpY/j8vhPqw==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-kit": "^7.3.4"
+        "@vue/devtools-kit": "^7.3.5"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.3.4.tgz",
-      "integrity": "sha512-DalQZWaFLRyA4qfKT0WT7e+q2AwvYoTwd0pWqswHqcpviXw+oU6FlSJHMrEACB3lBHjN1KBS9Kh527sWIe1vcg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.3.5.tgz",
+      "integrity": "sha512-wwfi10gJ1HMtjzcd8aIOnzBHlIRqsYDgcDyrKvkeyc0Gbcoe7UrkXRVHZUOtcxxoplHA0PwpT6wFg0uUCmi8Ww==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-shared": "^7.3.4",
+        "@vue/devtools-shared": "^7.3.5",
         "birpc": "^0.2.17",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
@@ -1015,9 +1033,9 @@
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.3.4.tgz",
-      "integrity": "sha512-5S5cHh7oWLZdboujnLteR3rT8UGfKHfA34aGLyFRB/B5TqBxmeLW1Rq32xW6TCDEy4isoYsYHGwJVp6DQcpiDA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.3.5.tgz",
+      "integrity": "sha512-Rqii3VazmWTi67a86rYopi61n5Ved05EybJCwyrfoO9Ok3MaS/4yRFl706ouoISMlyrASJFEzM0/AiDA6w4f9A==",
       "dev": true,
       "dependencies": {
         "rfdc": "^1.4.1"
@@ -1491,9 +1509,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "dev": true,
       "funding": [
         {
@@ -1511,7 +1529,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {
@@ -1617,12 +1635,13 @@
       "peer": true
     },
     "node_modules/shiki": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.9.1.tgz",
-      "integrity": "sha512-8PDkgb5ja3nfujTjvC4VytL6wGOGCtFAClUb2r3QROevYXxcq+/shVJK5s6gy0HZnjaJgFxd6BpPqpRfqne5rA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.3.tgz",
+      "integrity": "sha512-eneCLncGuvPdTutJuLyUGS8QNPAVFO5Trvld2wgEq1e002mwctAhJKeMGWtWVXOIEzmlcLRqcgPSorR6AVzOmQ==",
       "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.9.1"
+        "@shikijs/core": "1.10.3",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/source-map-js": {
@@ -1670,13 +1689,13 @@
       "peer": true
     },
     "node_modules/vite": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.2.tgz",
-      "integrity": "sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
+      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.38",
+        "postcss": "^8.4.39",
         "rollup": "^4.13.0"
       },
       "bin": {
@@ -1725,27 +1744,27 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.2.3.tgz",
-      "integrity": "sha512-GvEsrEeNLiDE1+fuwDAYJCYLNZDAna+EtnXlPajhv/MYeTjbNK6Bvyg6NoTdO1sbwuQJ0vuJR99bOlH53bo6lg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.3.0.tgz",
+      "integrity": "sha512-Cbm2AgXcCrukUeV+/24g1ZDSvw8blamh/1uf2pz3ApFpaYb9T7mo4imWDZ6APn2uPo4bJ6sgOzvsJ4aH+oLbBA==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.6.0",
         "@docsearch/js": "^3.6.0",
-        "@shikijs/core": "^1.6.2",
-        "@shikijs/transformers": "^1.6.2",
+        "@shikijs/core": "^1.10.3",
+        "@shikijs/transformers": "^1.10.3",
         "@types/markdown-it": "^14.1.1",
         "@vitejs/plugin-vue": "^5.0.5",
-        "@vue/devtools-api": "^7.2.1",
-        "@vue/shared": "^3.4.27",
-        "@vueuse/core": "^10.10.0",
-        "@vueuse/integrations": "^10.10.0",
+        "@vue/devtools-api": "^7.3.5",
+        "@vue/shared": "^3.4.31",
+        "@vueuse/core": "^10.11.0",
+        "@vueuse/integrations": "^10.11.0",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
-        "shiki": "^1.6.2",
-        "vite": "^5.2.12",
-        "vue": "^3.4.27"
+        "shiki": "^1.10.3",
+        "vite": "^5.3.3",
+        "vue": "^3.4.31"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
@@ -1785,9 +1804,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.10.tgz",
-      "integrity": "sha512-Myd9+EFq4Gmu61yKPNVS0QdGQkcZ9cHom27wuvRw7jgDxM+X4MT9BwQRk/Dt1q3G3JlK8oh+ZYyq5Ps/Z73cMg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.11.tgz",
+      "integrity": "sha512-DMreVZ6+WCVnvRoFVPGtC+Kc4afx+etcTLgX2AqUj6lQ4RrEx0TlQoNAW1oKPH4eViv2wfdvQ3xb/Yw1c86cTw==",
       "dev": true,
       "engines": {
         "node": "^12.20 || >=14.13"

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "@vueuse/core": "^10.11.0",
-    "vitepress": "^1.2.3",
+    "vitepress": "^1.3.0",
     "vue": "^3.4.31",
-    "vuetify": "^3.6.10"
+    "vuetify": "^3.6.11"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,9 +8,9 @@
     "docs:preview": "vitepress preview"
   },
   "devDependencies": {
-    "@vueuse/core": "^10.11.0",
-    "vitepress": "^1.3.0",
-    "vue": "^3.4.31",
-    "vuetify": "^3.6.11"
+    "@vueuse/core": "^11.0.3",
+    "vitepress": "^1.3.4",
+    "vue": "^3.5.3",
+    "vuetify": "^3.7.1"
   }
 }

--- a/src/__tests__/v2/client.test.ts
+++ b/src/__tests__/v2/client.test.ts
@@ -83,7 +83,7 @@ describe('oauth client', () => {
 
 
 describe('rest client', () => {
-    const client = createTestClient('creator', async () => new Response())['rest']
+    const client = createTestClient('creator', async () => new Response())['oauth']['rest']
 
     test('client', () => {
         expect(client.userAgent).toBeTypeOf('string')

--- a/src/payloads/v2/index.ts
+++ b/src/payloads/v2/index.ts
@@ -40,4 +40,5 @@ export type ListResourcePayload<
     >
 }[ResourceType]
 
+export * from './normalized/'
 export * from './webhook'

--- a/src/payloads/v2/normalized/capitalize.ts
+++ b/src/payloads/v2/normalized/capitalize.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
+    ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+    : Lowercase<S>
+
+type KeysToCamelCase<T> = {
+    [K in keyof T as CamelCase<string & K>]: T[K]
+}
+
+export type AnyToCamelCase<T> = T extends (infer A)[]
+    ? AnyToCamelCase<A>[]
+    : T extends object
+        ? { [K in keyof T as CamelCase<string & K>]: AnyToCamelCase<T[K]> }
+        : T
+
+/**
+ *
+ * @param obj
+ * @param key
+ */
+function toCamelcase <T extends string>(key: T): CamelCase<T> {
+    if (!key.includes('_')) return key as unknown as CamelCase<T>
+    const [first, second] = key.split('_', 2)
+    const combined = first.toLowerCase() + second.charAt(0).toUpperCase() + second.slice(1)
+
+    return toCamelcase(combined) as CamelCase<T>
+}
+
+/**
+ *
+ * @param item
+ */
+export function convertToCamelcase <T> (item: T): AnyToCamelCase<T>{
+    if (Array.isArray(item)) return <never>item.map(convertToCamelcase)
+    else if (typeof item === 'object' && item) {
+        return <never>Object.keys(item).reduce((obj, key) => ({
+            ...obj,
+            [toCamelcase(key)]: convertToCamelcase(obj[key]),
+        }), {} as KeysToCamelCase<T>)
+    } else return <never>item
+}

--- a/src/payloads/v2/normalized/find.ts
+++ b/src/payloads/v2/normalized/find.ts
@@ -1,0 +1,76 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import {
+    SchemaRelationshipKeys,
+    type DataItem,
+    type DataItems,
+    type ItemType,
+    type Relationship,
+    type RelationshipFields,
+    type RelationshipFieldToFieldType,
+    type RelationshipItem,
+    type RelationshipMap,
+} from '../../../schemas/v2/'
+
+import type { NormalizedRelationshipItem } from './payload'
+
+class NormalizedError extends Error {
+    public constructor (message: string) {
+        super('[Normalized] ' + message)
+    }
+}
+
+function getTypeForIncludeKey <Type extends ItemType, Field extends RelationshipFields<Type>>(type: Type, includeKey: Field): RelationshipFieldToFieldType<Type, Field> {
+    const fields = SchemaRelationshipKeys[type]
+    if (fields == undefined) throw new NormalizedError('No relationships found for type: ' + type)
+
+    // Can exclude never[] as it is an empty array
+    const resourceKey = (fields as Exclude<typeof fields, never[]>)
+        .find(f => f.includeKey === includeKey)?.resourceKey
+
+    if (resourceKey == undefined) throw new NormalizedError(`No resource key found for ${includeKey} on ${type}`)
+    return resourceKey as RelationshipFieldToFieldType<Type, Field>
+}
+
+function findRelation <
+    Type extends ItemType,
+    Fields extends RelationshipFields<Type>,
+    Map extends RelationshipMap<Type, Fields>
+>(
+    relationship: DataItem<Type, Fields> | DataItems<Type, Fields>,
+    included: RelationshipItem<Type, Fields, Map>[],
+) {
+    function searchRelation ({ data: { id, type } }: DataItem<Type, Fields>) {
+        const incl = included.find(f => f.id === id && f.type === type)
+        if (!incl) throw new NormalizedError('No included field for resource: ' + id)
+
+        return {
+            ...incl.attributes,
+            id: incl.id,
+            type: incl.type,
+        }
+    }
+
+    // Typecast to DataItem is okay since it only adds the unused links property
+    return Array.isArray(relationship.data)
+        ? (relationship.data).map(item => searchRelation({ data: item } as DataItem<Type, Fields>))
+        : searchRelation(relationship as DataItem<Type, Fields>)
+}
+
+export function findRelationships <
+    Type extends ItemType,
+    Fields extends RelationshipFields<Type>,
+    Map extends RelationshipMap<Type, Fields>
+>(
+    type: Type,
+    // keys: Fields[],
+    relationships: Relationship<Type, Fields>['relationships'] | undefined,
+    included: RelationshipItem<Type, Fields, Map>[] | undefined,
+) {
+    if (relationships == undefined || included == undefined) return {}
+    const keys: Fields[] = Object.keys(relationships) as keyof typeof relationships
+
+    return keys.reduce((found, key) => ({
+        ...found,
+        [getTypeForIncludeKey(type, key)]: findRelation<Type, Fields, Map>(relationships[key]['data'], included),
+    }), {} as Record<RelationshipFieldToFieldType<Type, Fields>, NormalizedRelationshipItem<Type, Fields, Map>>)
+}

--- a/src/payloads/v2/normalized/find.ts
+++ b/src/payloads/v2/normalized/find.ts
@@ -1,5 +1,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     SchemaRelationshipKeys,
     type DataItem,
     type DataItems,

--- a/src/payloads/v2/normalized/index.ts
+++ b/src/payloads/v2/normalized/index.ts
@@ -13,8 +13,9 @@ import type {
 import { BasePatreonQuery, GetResponsePayload } from '../../../v2'
 
 /**
- *
- * @param payload
+ * Returns if the payload has pagination data
+ * @param payload The payload to check
+ * @returns the result
  */
 export function isListingPayload <
     T extends Type,
@@ -25,8 +26,9 @@ export function isListingPayload <
 }
 
 /**
- *
- * @param payload
+ * Returns if the normalized payload has pagination data
+ * @param payload The payload to check
+ * @returns the result
  */
 export function isListingNormalizedPayload<
     T extends Type,
@@ -37,8 +39,9 @@ export function isListingNormalizedPayload<
 }
 
 /**
- *
+ * EXPERIMENTAL Issue a bug if something is broken
  * @param payload
+ * @returns
  */
 export function normalize <
     T extends Type,
@@ -90,8 +93,9 @@ export function normalize <
 }
 
 /**
- *
+ * EXPERIMENTAL Issue a bug if something is broken
  * @param payload
+ * @returns
  */
 export function normalizeFromQuery<
     Query extends BasePatreonQuery
@@ -100,8 +104,9 @@ export function normalizeFromQuery<
 }
 
 /**
- *
+ * EXPERIMENTAL Issue a bug if something is broken
  * @param payload
+ * @returns
  */
 export function simplify<
     T extends Type,
@@ -112,8 +117,9 @@ export function simplify<
 }
 
 /**
- *
+ * EXPERIMENTAL Issue a bug if something is broken
  * @param payload
+ * @returns
  */
 export function simplifyFromQuery<Query extends BasePatreonQuery>(payload: GetResponsePayload<Query>): AnyToCamelCase<GetNormalizedResponsePayload<Query>> {
     return convertToCamelcase(normalizeFromQuery(payload))

--- a/src/payloads/v2/normalized/index.ts
+++ b/src/payloads/v2/normalized/index.ts
@@ -1,0 +1,120 @@
+import { AnyToCamelCase, convertToCamelcase } from './capitalize'
+import { findRelationships } from './find'
+
+import type { RelationshipFields, RelationshipMap, Type } from '../../../schemas/v2/'
+import type { RequestPayload } from '../internals/request'
+
+import type {
+    GetNormalizedResponsePayload,
+    NormalizedGetRequestPayload,
+    NormalizedListRequestPayload,
+    NormalizedRequestPayload,
+} from './payload'
+import { BasePatreonQuery, GetResponsePayload } from '../../../v2'
+
+/**
+ *
+ * @param payload
+ */
+export function isListingPayload <
+    T extends Type,
+    Includes extends RelationshipFields<T> = never,
+    Attributes extends RelationshipMap<T, Includes> = never,
+>(payload: RequestPayload<T, Includes, Attributes, boolean>): payload is RequestPayload<T, Includes, Attributes, true> {
+    return 'meta' in payload ? payload.meta.pagination != undefined : false
+}
+
+/**
+ *
+ * @param payload
+ */
+export function isListingNormalizedPayload<
+    T extends Type,
+    Includes extends RelationshipFields<T> = never,
+    Attributes extends RelationshipMap<T, Includes> = never,
+>(payload: NormalizedRequestPayload<T, Includes, Attributes>): payload is NormalizedListRequestPayload<T, Includes, Attributes> {
+    return 'pagination' in payload ? payload.pagination != undefined : false
+}
+
+/**
+ *
+ * @param payload
+ */
+export function normalize <
+    T extends Type,
+    Includes extends RelationshipFields<T> = never,
+    Attributes extends RelationshipMap<T, Includes> = never,
+>(payload: RequestPayload<T, Includes, Attributes, boolean>): NormalizedRequestPayload<T, Includes, Attributes> {
+    if (isListingPayload(payload)) {
+        const normalized: NormalizedListRequestPayload<Type, Includes, Attributes> = {
+            data: payload.data.map(item => {
+                const relationships = findRelationships<T, Includes, Attributes>(
+                    item.type,
+                    // TODO: figure out why type is unknown
+                    'relationships' in item ? <never>item.relationships : undefined,
+                    'included' in payload ? <never>payload.included : undefined,
+                )
+
+                return {
+                    ...item.attributes,
+                    ...relationships,
+                    id: item.id,
+                    type: item.type,
+                }
+            }),
+            pagination: {
+                total: payload.meta.pagination.total,
+                next_cursor: payload.meta.pagination.cursors?.next ?? null,
+            },
+        }
+
+        return normalized as NormalizedRequestPayload<T, Includes, Attributes>
+    } else {
+        const relationships = findRelationships<T, Includes, Attributes>(
+            payload.data.type,
+            // TODO: figure out why type is unknown
+            'relationships' in payload.data ? <never>payload.data.relationships : undefined,
+            'included' in payload ? <never>payload.included : undefined,
+        )
+
+        const normalized: NormalizedGetRequestPayload<Type, Includes, Attributes> = {
+            ...payload.data.attributes,
+            ...relationships,
+            id: payload.data.id,
+            type: payload.data.type,
+            link: payload.links.self,
+        }
+
+        return normalized as NormalizedRequestPayload<T, Includes, Attributes>
+    }
+}
+
+/**
+ *
+ * @param payload
+ */
+export function normalizeFromQuery<
+    Query extends BasePatreonQuery
+>(payload: GetResponsePayload<Query>): GetNormalizedResponsePayload<Query> {
+    return normalize(payload) as GetNormalizedResponsePayload<Query>
+}
+
+/**
+ *
+ * @param payload
+ */
+export function simplify<
+    T extends Type,
+    Includes extends RelationshipFields<T> = never,
+    Attributes extends RelationshipMap<T, Includes> = never,
+>(payload: RequestPayload<T, Includes, Attributes, boolean>): AnyToCamelCase<NormalizedRequestPayload<T, Includes, Attributes>> {
+    return convertToCamelcase(normalize(payload))
+}
+
+/**
+ *
+ * @param payload
+ */
+export function simplifyFromQuery<Query extends BasePatreonQuery>(payload: GetResponsePayload<Query>): AnyToCamelCase<GetNormalizedResponsePayload<Query>> {
+    return convertToCamelcase(normalizeFromQuery(payload))
+}

--- a/src/payloads/v2/normalized/payload.ts
+++ b/src/payloads/v2/normalized/payload.ts
@@ -1,0 +1,65 @@
+import { BasePatreonQuery, PatreonQuery } from '../../../rest/v2/query'
+import type {
+    Item,
+    ItemMap,
+    ItemType,
+    RelationshipFieldToFieldType,
+    RelationshipFields,
+    RelationshipMainItemAttributes,
+    RelationshipMap,
+    RelationshipTypeFields,
+} from '../../../schemas/v2/'
+
+import type { AdditionalKeys } from '../../../utils'
+
+export type NormalizedAttributeItem<
+    Type extends ItemType,
+    Attributes extends Record<string, unknown> = Record<string, never>
+> = Item<Type> & Attributes
+
+type NormalizedRelationshipItemProperty<T extends ItemType, Key extends RelationshipTypeFields<T>, Map extends RelationshipMap<T, Key>> = {
+    [K in Key]: Key extends keyof Map ? Map[Key] extends infer Value ? Value extends string[] ? Value[number] : never : never : never
+}
+
+export type NormalizedRelationshipItem<
+    T extends ItemType,
+    Key extends RelationshipFields<T>,
+    Map extends RelationshipMap<T, Key>
+> = {
+    [K in RelationshipFieldToFieldType<T, Key>]: NormalizedAttributeItem<K, Pick<ItemMap[K], NormalizedRelationshipItemProperty<T, RelationshipFieldToFieldType<T, Key>, Map>[K]>>
+}[RelationshipFieldToFieldType<T, Key>]
+
+export type NormalizedGetRequestPayload<
+    Type extends `${ItemType}`,
+    Keys extends RelationshipFields<Type>,
+    Attributes extends RelationshipMap<Type, Keys>,
+> = NormalizedAttributeItem<Type, RelationshipMainItemAttributes<Type, Keys, Attributes>>
+    & AdditionalKeys<Keys, { [Key in Keys]: NormalizedRelationshipItem<Type, Key, Attributes> }>
+    & { link: string }
+
+export type NormalizedListRequestPayload<
+    Type extends `${ItemType}`,
+    Keys extends RelationshipFields<Type>,
+    Attributes extends RelationshipMap<Type, Keys>,
+> = {
+    data: (
+        NormalizedAttributeItem<Type, RelationshipMainItemAttributes<Type, Keys, Attributes>>
+        & AdditionalKeys<Keys, { [Key in Keys]: NormalizedRelationshipItem<Type, Key, Attributes> }>
+    )[]
+    pagination: {
+        total: number
+        next_cursor: string | null
+    }
+}
+
+export type NormalizedRequestPayload<
+    Type extends `${ItemType}`,
+    Keys extends RelationshipFields<Type>,
+    Attributes extends RelationshipMap<Type, Keys>,
+> =
+    | NormalizedGetRequestPayload<Type, Keys, Attributes>
+    | NormalizedListRequestPayload<Type, Keys, Attributes>
+
+export type GetNormalizedResponsePayload<Query extends BasePatreonQuery> = Query extends PatreonQuery<infer T, infer I, infer A, infer L>
+    ? L extends true ? NormalizedListRequestPayload<T, I, A> : NormalizedGetRequestPayload<T, I, A>
+    : never

--- a/src/rest/v2/clients/base.ts
+++ b/src/rest/v2/clients/base.ts
@@ -68,18 +68,18 @@ export abstract class PatreonClient extends PatreonClientMethods {
      */
     public webhooks: WebhookClient
 
-    public constructor(patreonOptions: PatreonClientOptions) {
-        super(patreonOptions.oauth, patreonOptions.rest)
+    public constructor(options: PatreonClientOptions) {
+        super(options.oauth, options.rest)
         this.webhooks = new WebhookClient(this.oauth)
 
-        this.name = patreonOptions.name ?? null
-        this.store = patreonOptions.store
+        this.name = options.name ?? null
+        this.store = options.store
 
         this.oauth.onTokenRefreshed = async (token) => {
             if (token) await this.putStoredToken?.(token, true)
         }
 
-        this.rest.options.getAccessToken ??= async () => {
+        this.oauth['rest'].options.getAccessToken ??= async () => {
             return await this.fetchStoredToken()
                 .then(token => token?.access_token)
         }

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -1,5 +1,11 @@
-import type { BasePatreonQuery, BasePatreonQueryType, GetResponsePayload } from '../query'
+import { normalizeFromQuery, simplifyFromQuery } from '../../../payloads/v2'
 import type { Type } from '../../../schemas/v2'
+
+import type {
+    BasePatreonQuery,
+    BasePatreonQueryType,
+    GetResponsePayload,
+} from '../query'
 
 import {
     CreatorToken,
@@ -8,9 +14,14 @@ import {
     type StoredToken,
 } from '../oauth2/client'
 
+import {
+    RestClient,
+    type RequestMethod,
+    type RequestOptions,
+    type RESTOptions,
+} from '../oauth2/rest'
+
 import { Oauth2Routes } from '../oauth2/routes'
-import { RequestMethod, RequestOptions, RestClient, type RESTOptions } from '../oauth2/rest'
-import { normalizeFromQuery, simplifyFromQuery } from '../../../v2'
 
 type BaseFetchOptions = Omit<RequestOptions,
     | 'route'

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -186,7 +186,18 @@ class GenericPatreonClientMethods<TransformType extends ResponseTransformType> {
 export abstract class PatreonClientMethods extends GenericPatreonClientMethods<'default'> {
     public oauth: PatreonOauthClient
 
+    /**
+     * EXPERIMENTAL
+     *
+     * Issue a bug if something is broken
+     */
     public simplified: GenericPatreonClientMethods<'simplified'>
+
+    /**
+     * EXPERIMENTAL
+     *
+     * Issue a bug if something is broken
+     */
     public normalized: GenericPatreonClientMethods<'normalized'>
 
     public constructor (

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -1,3 +1,5 @@
+/* eslint-disable jsdoc/require-returns */
+/* eslint-disable jsdoc/require-param */
 import { normalizeFromQuery, simplifyFromQuery } from '../../../payloads/v2'
 import type { Type } from '../../../schemas/v2'
 
@@ -181,10 +183,10 @@ class GenericPatreonClientMethods<TransformType extends ResponseTransformType> {
 }
 
 
-export abstract class PatreonClientMethods extends GenericPatreonClientMethods<'simplified'> {
+export abstract class PatreonClientMethods extends GenericPatreonClientMethods<'default'> {
     public oauth: PatreonOauthClient
 
-    public api: GenericPatreonClientMethods<'default'>
+    public simplified: GenericPatreonClientMethods<'simplified'>
     public normalized: GenericPatreonClientMethods<'normalized'>
 
     public constructor (
@@ -195,12 +197,12 @@ export abstract class PatreonClientMethods extends GenericPatreonClientMethods<'
         const restClient = new RestClient(rest)
         const oauth = new PatreonOauthClient(rawOauthOptions, restClient)
 
-        super(oauth, 'simplified', _token)
+        super(oauth, 'default', _token)
 
         this.oauth = oauth
 
         this.normalized = new GenericPatreonClientMethods(oauth, 'normalized', _token)
-        this.api = new GenericPatreonClientMethods(oauth, 'default', _token)
+        this.simplified = new GenericPatreonClientMethods(oauth, 'simplified', _token)
     }
 }
 

--- a/src/rest/v2/clients/baseMethods.ts
+++ b/src/rest/v2/clients/baseMethods.ts
@@ -1,5 +1,5 @@
 import type { BasePatreonQuery, BasePatreonQueryType, GetResponsePayload } from '../query'
-import { Type } from '../../../schemas/v2'
+import type { Type } from '../../../schemas/v2'
 
 import {
     CreatorToken,
@@ -10,6 +10,7 @@ import {
 
 import { Oauth2Routes } from '../oauth2/routes'
 import { RequestMethod, RequestOptions, RestClient, type RESTOptions } from '../oauth2/rest'
+import { normalizeFromQuery, simplifyFromQuery } from '../../../v2'
 
 type BaseFetchOptions = Omit<RequestOptions,
     | 'route'
@@ -40,31 +41,31 @@ export interface Oauth2FetchOptions extends BaseFetchOptions {
  */
 export type Oauth2RouteOptions = Omit<Oauth2FetchOptions, 'method'>
 
-interface OauthClient {
-    fetchOauth2<Query extends BasePatreonQuery>(
-        path: string,
-        query: Query,
-        options?: Oauth2FetchOptions,
-    ): Promise<GetResponsePayload<Query> | undefined>
-
-    listOauth2<Query extends BasePatreonQuery>(
-        path: string,
-        query: Query,
-        options?: Oauth2FetchOptions,
-    ): AsyncGenerator<GetResponsePayload<Query>, number>
+// TODO: replace with generics once https://github.com/Microsoft/TypeScript/issues/1213 is closed
+interface GetResponseMap<Query extends BasePatreonQuery> {
+    default: (res: GetResponsePayload<Query>) => GetResponsePayload<Query>
+    simplified: (res: GetResponsePayload<Query>) => ReturnType<typeof simplifyFromQuery<Query>>
+    normalized: (res: GetResponsePayload<Query>) => ReturnType<typeof normalizeFromQuery<Query>>
 }
 
-export abstract class PatreonClientMethods implements OauthClient {
-    public oauth: PatreonOauthClient
-    protected rest: RestClient
+export type ResponseTransformType = keyof GetResponseMap<BasePatreonQuery>
 
+class GenericPatreonClientMethods<TransformType extends ResponseTransformType> {
     public constructor (
-        protected rawOauthOptions: PatreonOauthClientOptions,
-        rest: Partial<RESTOptions> = {},
+        protected _oauth: PatreonOauthClient,
+        private _replacer: TransformType,
         private _token?: StoredToken,
-    ) {
-        this.rest = new RestClient(rest)
-        this.oauth = new PatreonOauthClient(rawOauthOptions, this.rest)
+    ) {}
+
+    private _replace <Query extends BasePatreonQuery> (res: GetResponsePayload<Query>): ReturnType<GetResponseMap<Query>[TransformType]> {
+        const map: GetResponseMap<Query> = {
+            default: (res) => res,
+            simplified: (res) => simplifyFromQuery(res),
+            normalized: (res) => normalizeFromQuery(res),
+        }
+
+        const replacer = map[this._replacer]
+        return replacer(res) as ReturnType<typeof replacer>
     }
 
     /**
@@ -72,32 +73,50 @@ export abstract class PatreonClientMethods implements OauthClient {
      * @param path The Oauth V2 API Route
      * @param query The query builder with included fields and attributes
      * @param options Request options
-     * @returns the response for succesful requests, otherwise undefined.
+     * @returns the response for succesful requests
+     * @throws on failed request
      */
     public async fetchOauth2<Query extends BasePatreonQuery>(
         path: string,
         query: Query,
         options?: Oauth2FetchOptions | undefined
-    ): Promise<GetResponsePayload<Query> | undefined> {
+    ) {
         if (this._token) {
             options ??= {}
             options.token ??= this._token
         }
 
-        return await this.oauth.fetch<Query>(path, query, options)
+        return await this._oauth.fetch(path, query, options)
+            .then(res => this._replace<Query>(res))
     }
 
-    public listOauth2<Query extends BasePatreonQuery>(
+    /**
+     * Paginate the Patreon Oauth V2 API until all pages are fetched
+     * @param path The Oauth V2 API Route
+     * @param query The query builder with included fields and attributes
+     * @param options Request options
+     * @yields a page of response data
+     * @returns the amount of pages fetched
+     */
+    public async *paginateOauth2<Query extends BasePatreonQuery>(
         path: string,
         query: Query,
         options?: Oauth2FetchOptions | undefined
-    ): AsyncGenerator<GetResponsePayload<Query>, number, unknown> {
+    ) {
         if (this._token) {
             options ??= {}
             options.token ??= this._token
         }
 
-        return this.oauth.paginate(path, query, options)
+        const paginator = this._oauth.paginate(path, query, options)
+
+        let page = await paginator.next()
+        while (!page.done) {
+            yield this._replace(page.value)
+            page = await paginator.next()
+        }
+
+        return page.value
     }
 
     public async fetchCampaigns <Query extends BasePatreonQueryType<Type.Campaign, true>>(query: Query, options?: Oauth2RouteOptions) {
@@ -128,16 +147,49 @@ export abstract class PatreonClientMethods implements OauthClient {
         return await this.fetchOauth2<Query>(Oauth2Routes.identity(), query, options)
     }
 
-    public listCampaigns <Query extends BasePatreonQueryType<Type.Campaign, true>>(query: Query, options?: Oauth2RouteOptions) {
-        return this.listOauth2<Query>(Oauth2Routes.campaigns(), query, options)
+    public paginateCampaigns <Query extends BasePatreonQueryType<Type.Campaign, true>>(query: Query, options?: Oauth2RouteOptions) {
+        return this.paginateOauth2<Query>(Oauth2Routes.campaigns(), query, options)
     }
 
-    public listCampaignMembers <Query extends BasePatreonQueryType<Type.Member, true>>(campaignId: string, query: Query, options?: Oauth2RouteOptions) {
-        return this.listOauth2<Query>(Oauth2Routes.campaignMembers(campaignId), query, options)
+    public paginateCampaignMembers <Query extends BasePatreonQueryType<Type.Member, true>>(campaignId: string, query: Query, options?: Oauth2RouteOptions) {
+        return this.paginateOauth2<Query>(Oauth2Routes.campaignMembers(campaignId), query, options)
     }
 
-    public listCampaignPosts <Query extends BasePatreonQueryType<Type.Post, true>>(campaignId: string, query: Query, options?: Oauth2RouteOptions) {
-        return this.listOauth2<Query>(Oauth2Routes.campaignPosts(campaignId), query, options)
+    public paginateCampaignPosts <Query extends BasePatreonQueryType<Type.Post, true>>(campaignId: string, query: Query, options?: Oauth2RouteOptions) {
+        return this.paginateOauth2<Query>(Oauth2Routes.campaignPosts(campaignId), query, options)
+    }
+
+    /** @deprecated */
+    public listOauth2: GenericPatreonClientMethods<TransformType>['paginateOauth2'] = (...args) => this.paginateOauth2(...args)
+    /** @deprecated */
+    public listCampaignPosts: GenericPatreonClientMethods<TransformType>['paginateCampaignPosts'] = (...args) => this.paginateCampaignPosts(...args)
+    /** @deprecated */
+    public listCampaignMembers: GenericPatreonClientMethods<TransformType>['paginateCampaignMembers'] = (...args) => this.paginateCampaignMembers(...args)
+    /** @deprecated */
+    public listCampaigns: GenericPatreonClientMethods<TransformType>['paginateCampaigns'] = (...args) => this.paginateCampaigns(...args)
+}
+
+
+export abstract class PatreonClientMethods extends GenericPatreonClientMethods<'simplified'> {
+    public oauth: PatreonOauthClient
+
+    public api: GenericPatreonClientMethods<'default'>
+    public normalized: GenericPatreonClientMethods<'normalized'>
+
+    public constructor (
+        protected rawOauthOptions: PatreonOauthClientOptions,
+        rest: Partial<RESTOptions> = {},
+        _token?: StoredToken,
+    ) {
+        const restClient = new RestClient(rest)
+        const oauth = new PatreonOauthClient(rawOauthOptions, restClient)
+
+        super(oauth, 'simplified', _token)
+
+        this.oauth = oauth
+
+        this.normalized = new GenericPatreonClientMethods(oauth, 'normalized', _token)
+        this.api = new GenericPatreonClientMethods(oauth, 'default', _token)
     }
 }
 

--- a/src/rest/v2/clients/user.ts
+++ b/src/rest/v2/clients/user.ts
@@ -23,8 +23,8 @@ export class PatreonUserClientInstance extends PatreonClientMethods {
 
         return await this.fetchIdentity(query, { token: this.token })
             .then(res => {
-                const option = <{ userId: string } | null>(res.socialConnections.discord)
-                return option?.userId
+                const option = <{ user_id: string } | null>(res.data.attributes.social_connections.discord)
+                return option?.user_id
             })
     }
 }

--- a/src/rest/v2/clients/user.ts
+++ b/src/rest/v2/clients/user.ts
@@ -23,8 +23,8 @@ export class PatreonUserClientInstance extends PatreonClientMethods {
 
         return await this.fetchIdentity(query, { token: this.token })
             .then(res => {
-                const option = <{ user_id: string } | null>(res?.data.attributes.social_connections.discord)
-                return option?.user_id
+                const option = <{ userId: string } | null>(res.socialConnections.discord)
+                return option?.userId
             })
     }
 }

--- a/src/rest/v2/clients/user.ts
+++ b/src/rest/v2/clients/user.ts
@@ -7,7 +7,7 @@ export class PatreonUserClientInstance extends PatreonClientMethods {
     public client: PatreonUserClient
 
     public constructor (client: PatreonUserClient, token: StoredToken) {
-        super(client['rawOauthOptions'], client['rest'].options, token)
+        super(client['rawOauthOptions'], client.oauth['rest'].options, token)
         this.client = client
         this.token = token
     }

--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -210,9 +210,10 @@ export class PatreonOauthClient {
         options?: Oauth2FetchOptions,
     ): AsyncGenerator<GetResponsePayload<Query>, number, unknown> {
         let done = false, page = 1
+        let cursor: string | undefined = undefined
 
         while (!done) {
-            query.params.set('page[count]', page.toString())
+            if (cursor) query.params.set('page[cursor]', cursor)
             const pageQuery = createQuery(query.params) as unknown as Query
 
             const response = await this.fetch(path, pageQuery, options)
@@ -221,6 +222,7 @@ export class PatreonOauthClient {
 
             if ('meta' in response && response.meta.pagination.cursors?.next) {
                 page += 1
+                cursor = response.meta.pagination.cursors.next
             } else {
                 done = true
             }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,7 @@ export default defineConfig({
             exclude: [
                 '**/schemas/v2/generated/',
                 '**/schemas/v2/scripts/',
+                '**/payloads/v2/normalized/'
             ],
             thresholds: {
                 branches: threshold,


### PR DESCRIPTION
<!-- 
Before creating a pull request:
- open an issue
- make sure all the tests (and coverage) pass
- run linter and typescript compiler
 -->
 
 - The functions `simplifyFromQuery` and `normalizeFromQuery` will perform the same transformations as mentioned below but are typed based on the query to give the output type.

Adds two new response types:

`normalize`:
- flattens all attributes, included and relationship fields to one object.
- Exposed on the client with `<Client>.normalized`

`simplify`:
- Will return the same as `normalize` with camelCase keys
- Expose on the client with `<Client>.simplified`

## Changes this PR makes

- fix(PatreonOauthClient): remove undefined from return types
- fix(PatreonOauthClient): correctly use cursor for paginating
- feat(rest): add `timeout` option to client
