### PR TITLE
feat(rest): deprecate certain types

### DIFF
--- a/src/rest/v2/clients/base.ts
+++ b/src/rest/v2/clients/base.ts
@@ -3,10 +3,15 @@ import {
     type GetResponseMap,
     type Oauth2FetchOptions,
     type Oauth2RouteOptions,
+    type ResponseTransformMap,
+    type ResponseTransformType,
 } from './baseMethods'
 
 import {
     type CreatorToken,
+    type Oauth2CreatorToken,
+    type Oauth2StoredToken,
+    type Oauth2Token,
     type PatreonOauthClientOptions,
     type StoredToken,
     type Token,
@@ -20,6 +25,11 @@ import { WebhookClient } from '../webhooks'
 
 export type {
     GetResponseMap,
+    ResponseTransformMap,
+    ResponseTransformType,
+    Oauth2CreatorToken,
+    Oauth2StoredToken,
+    Oauth2Token,
     Oauth2FetchOptions,
     Oauth2RouteOptions,
     CreatorToken,
@@ -30,7 +40,7 @@ export type {
 /**
  * The constructor options for API applications
  */
-export type PatreonClientOptions = {
+export interface PatreonClientOptions {
     /**
      * The Oauth options for this client.
      * Required for both creator and user clients.

--- a/src/rest/v2/oauth2/index.ts
+++ b/src/rest/v2/oauth2/index.ts
@@ -6,6 +6,7 @@ export {
     DefaultRestOptions,
     PATREON_RESPONSE_HEADERS,
     RequestMethod,
+    ResponseHeaders,
     type InternalRequestOptions,
     type PatreonErrorData,
     type PatreonHeadersData,

--- a/src/rest/v2/oauth2/rest.ts
+++ b/src/rest/v2/oauth2/rest.ts
@@ -186,12 +186,15 @@ export interface RequestOptions {
     signal?: AbortSignal | undefined
 }
 
-export const PATREON_RESPONSE_HEADERS = {
+export const ResponseHeaders = {
     Sha: 'x-patreon-sha',
     UUID: 'x-patreon-uuid',
     CfCacheStatus: 'cf-cache-status',
     CfRay: 'cf-ray',
 } as const
+
+/** @deprecated */
+export const PATREON_RESPONSE_HEADERS = ResponseHeaders
 
 export const DefaultRestOptions: RESTOptions = {
     authPrefix: 'Bearer',
@@ -214,7 +217,7 @@ export enum RequestMethod {
     Post = 'POST',
 }
 
-export type PatreonHeadersData = Record<Lowercase<keyof typeof PATREON_RESPONSE_HEADERS>, string | null>
+export type PatreonHeadersData = Record<Lowercase<keyof typeof ResponseHeaders>, string | null>
 
 export interface InternalRequestOptions extends RequestOptions {
     path: string
@@ -562,10 +565,10 @@ export class RestClient {
      */
     public getHeaders (response: RestResponse): PatreonHeadersData {
         return {
-            sha: response.headers.get(PATREON_RESPONSE_HEADERS.Sha),
-            uuid: response.headers.get(PATREON_RESPONSE_HEADERS.UUID),
-            cfcachestatus: response.headers.get(PATREON_RESPONSE_HEADERS.CfCacheStatus),
-            cfray: response.headers.get(PATREON_RESPONSE_HEADERS.CfRay),
+            sha: response.headers.get(ResponseHeaders.Sha),
+            uuid: response.headers.get(ResponseHeaders.UUID),
+            cfcachestatus: response.headers.get(ResponseHeaders.CfCacheStatus),
+            cfray: response.headers.get(ResponseHeaders.CfRay),
         }
     }
 }

--- a/src/rest/v2/oauth2/routes.ts
+++ b/src/rest/v2/oauth2/routes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jsdoc/require-returns */
-export const Oauth2Routes = {
+export const Routes = {
     /**
      * Routes for:
      *
@@ -89,3 +89,5 @@ export const Oauth2Routes = {
     },
 }
 
+/** @deprecated */
+export const Oauth2Routes = Routes

--- a/src/rest/v2/oauth2/store.ts
+++ b/src/rest/v2/oauth2/store.ts
@@ -19,11 +19,6 @@ export interface PatreonTokenFetchOptions {
     get: () => Promise<StoredToken | undefined>
 }
 
-export interface KVLikeStore {
-    get: (key: string) => Promise<string | null>
-    put: (key: string, value: string) => Promise<void>
-}
-
 class PatreonFetchStore implements PatreonTokenFetchOptions {
     public get: () => Promise<StoredToken | undefined>
     public put: (token: StoredToken, url?: string | undefined) => Promise<void>
@@ -48,6 +43,14 @@ class PatreonFetchStore implements PatreonTokenFetchOptions {
     }
 }
 
+export interface PatreonStoreKVStorage {
+    get: (key: string) => Promise<string | null>
+    put: (key: string, value: string) => Promise<void>
+}
+
+/** @deprecated */
+export type KVLikeStore = PatreonStoreKVStorage
+
 /**
  * A store for Patreon tokens stored in a KV-like resource.
  */
@@ -60,7 +63,7 @@ class PatreonKVStore implements PatreonTokenFetchOptions {
      * @param store the external KV-like store to use for synchronizing tokens
      * @param tokenKey the key in the store to save the token in
      */
-    public constructor (store: KVLikeStore, tokenKey: string) {
+    public constructor (store: PatreonStoreKVStorage, tokenKey: string) {
         this.get = async () => await store.get(tokenKey)
             .then(value => value ? JSON.parse(value) : undefined)
             .catch(() => undefined)

--- a/src/schemas/v2/resources/webhook.ts
+++ b/src/schemas/v2/resources/webhook.ts
@@ -31,12 +31,14 @@ export interface Webhook {
     uri: string
 }
 
+/** @deprecated */
 export type PatchWebhookBody = Partial<Pick<Webhook,
     | 'paused'
     | 'triggers'
     | 'uri'
 >>
 
+/** @deprecated */
 export type PostWebhookBody = Pick<Webhook,
     | 'triggers'
     | 'uri'


### PR DESCRIPTION
<!-- 
Before creating a pull request:
- open an issue
- make sure all the tests (and coverage) pass
- run linter and typescript compiler
 -->

## Changes this PR makes

Deprecates: `Oauth2Routes`, `PATREON_RESPONSE_HEADERS`
Deprecates types: `CreatorToken`, `StoredToken`, `Token`, `KVLikeStore`, `GetResponseMap` and webhook API types 
