### PR TITLE
feat: add better query builder

### DIFF
--- a/src/schemas/v2/generated/schemas.ts
+++ b/src/schemas/v2/generated/schemas.ts
@@ -1,6 +1,6 @@
 export const Address = {
-    resource: 'address',
-    properties: [
+    resource: <const>'address',
+    properties: <const>[
         'addressee',
         'city',
         'country',
@@ -11,7 +11,7 @@ export const Address = {
         'postal_code',
         'state',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaigns', type: 'array'
         },
@@ -21,8 +21,8 @@ export const Address = {
     ],
 }
 export const Benefit = {
-    resource: 'benefit',
-    properties: [
+    resource: <const>'benefit',
+    properties: <const>[
         'app_external_id',
         'app_meta',
         'benefit_type',
@@ -39,7 +39,7 @@ export const Benefit = {
         'tiers_count',
         'title',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'array'
         },
@@ -52,8 +52,8 @@ export const Benefit = {
     ],
 }
 export const Campaign = {
-    resource: 'campaign',
-    properties: [
+    resource: <const>'campaign',
+    properties: <const>[
         'vanity',
         'url',
         'thanks_video_url',
@@ -82,7 +82,7 @@ export const Campaign = {
         'creation_name',
         'created_at',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'benefit', name: 'benefits', type: 'array'
         },
@@ -98,13 +98,13 @@ export const Campaign = {
     ],
 }
 export const Deliverable = {
-    resource: 'deliverable',
-    properties: [
+    resource: <const>'deliverable',
+    properties: <const>[
         'completed_at',
         'delivery_status',
         'due_at',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'benefit', name: 'benefit', type: 'item'
         },
@@ -120,18 +120,18 @@ export const Deliverable = {
     ],
 }
 export const Goal = {
-    resource: 'goal',
-    properties: [
+    resource: <const>'goal',
+    properties: <const>[
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'item'
         },
     ],
 }
 export const Media = {
-    resource: 'media',
-    properties: [
+    resource: <const>'media',
+    properties: <const>[
         'created_at',
         'download_url',
         'file_name',
@@ -147,12 +147,12 @@ export const Media = {
         'upload_parameters',
         'upload_url',
     ],
-    relationships: [
+    relationships: <const>[
     ],
 }
 export const Member = {
-    resource: 'member',
-    properties: [
+    resource: <const>'member',
+    properties: <const>[
         'campaign_lifetime_support_cents',
         'currently_entitled_amount_cents',
         'email',
@@ -170,7 +170,7 @@ export const Member = {
         'pledge_relationship_start',
         'will_pay_amount_cents',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'address', name: 'address', type: 'item'
         },
@@ -189,8 +189,8 @@ export const Member = {
     ],
 }
 export const OauthClient = {
-    resource: 'client',
-    properties: [
+    resource: <const>'client',
+    properties: <const>[
         'author_name',
         'category',
         'client_secret',
@@ -204,7 +204,7 @@ export const OauthClient = {
         'tos_url',
         'version',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'item'
         },
@@ -214,8 +214,8 @@ export const OauthClient = {
     ],
 }
 export const PledgeEvent = {
-    resource: 'pledge-event',
-    properties: [
+    resource: <const>'pledge-event',
+    properties: <const>[
         'amount_cents',
         'currency_code',
         'date',
@@ -225,7 +225,7 @@ export const PledgeEvent = {
         'tier_title',
         'type',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'item'
         },
@@ -238,8 +238,8 @@ export const PledgeEvent = {
     ],
 }
 export const Post = {
-    resource: 'post',
-    properties: [
+    resource: <const>'post',
+    properties: <const>[
         'app_id',
         'app_status',
         'content',
@@ -252,7 +252,7 @@ export const Post = {
         'title',
         'url',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'user', name: 'user', type: 'item'
         },
@@ -262,8 +262,8 @@ export const Post = {
     ],
 }
 export const Tier = {
-    resource: 'tier',
-    properties: [
+    resource: <const>'tier',
+    properties: <const>[
         'amount_cents',
         'created_at',
         'description',
@@ -281,7 +281,7 @@ export const Tier = {
         'url',
         'user_limit',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'benefit', name: 'benefits', type: 'array'
         },
@@ -294,8 +294,8 @@ export const Tier = {
     ],
 }
 export const User = {
-    resource: 'user',
-    properties: [
+    resource: <const>'user',
+    properties: <const>[
         'about',
         'can_see_nsfw',
         'created',
@@ -313,7 +313,7 @@ export const User = {
         'url',
         'vanity',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'item'
         },
@@ -323,8 +323,8 @@ export const User = {
     ],
 }
 export const Webhook = {
-    resource: 'webhook',
-    properties: [
+    resource: <const>'webhook',
+    properties: <const>[
         'last_attempted_at',
         'num_consecutive_times_failed',
         'paused',
@@ -332,7 +332,7 @@ export const Webhook = {
         'triggers',
         'uri',
     ],
-    relationships: [
+    relationships: <const>[
         {
             resource: 'campaign', name: 'campaign', type: 'item'
         },

--- a/src/schemas/v2/index.ts
+++ b/src/schemas/v2/index.ts
@@ -1,4 +1,5 @@
 export * from './item'
+export * from './query'
 export * from './relationships'
 
 export * from './resources/address'

--- a/src/schemas/v2/query.ts
+++ b/src/schemas/v2/query.ts
@@ -1,0 +1,82 @@
+import {
+    type BasePatreonQuery,
+    buildQuery,
+    type QueryRequestOptions,
+} from '../../rest/v2/query'
+
+import type {
+    RelationshipFields,
+    RelationshipMap,
+} from './relationships'
+
+import * as SchemaResourcesData from './generated/schemas'
+
+import { Type } from './item'
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function getResource <T extends Type>(t: T) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return Object.values(SchemaResourcesData).find(d => d.resource === t)! as (
+        typeof SchemaResourcesData[keyof typeof SchemaResourcesData] extends infer D
+            ? D extends typeof SchemaResourcesData[keyof typeof SchemaResourcesData]
+                ? D['resource'] extends T
+                    ? D
+                    : never
+                : never
+            : never
+    )
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function createCompleteQueryOptions <
+    T extends Type
+>(t: T) {
+    const data = getResource(t)
+    const { properties, relationships, resource } = data
+
+    return {
+        include: data.relationships.map(n => n.name) as RelationshipFields<T>[],
+        attributes: {
+            [resource]: properties,
+            ...relationships.reduce((obj, n) => ({
+                ...obj,
+                [n.resource]: Object.values(SchemaResourcesData).find(d => d.resource === n.resource)?.properties ?? [],
+            }), {})
+        } as RelationshipMap<T, RelationshipFields<T>>
+    }
+}
+
+export const buildCompleteQuery = {
+    campaign: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Campaign)
+        return buildQuery.campaign(include)(attributes, options)
+    },
+    campaignMembers: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Member)
+        return buildQuery.campaignMembers(include)(attributes, options)
+    },
+    campaignPosts: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Post)
+        return buildQuery.campaignPosts(include)(attributes, options)
+    },
+    campaigns: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Campaign)
+        return buildQuery.campaigns(include)(attributes, options)
+    },
+    identity: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.User)
+        return buildQuery.identity(include)(attributes, options)
+    },
+    member: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Member)
+        return buildQuery.member(include)(attributes, options)
+    },
+    post: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Post)
+        return buildQuery.post(include)(attributes, options)
+    },
+    webhooks: (options?: QueryRequestOptions) => {
+        const { attributes, include } = createCompleteQueryOptions(Type.Webhook)
+        return buildQuery.webhooks(include)(attributes, options)
+    },
+} satisfies Record<keyof typeof buildQuery, (options?: QueryRequestOptions) => BasePatreonQuery>

--- a/src/schemas/v2/query.ts
+++ b/src/schemas/v2/query.ts
@@ -1,17 +1,33 @@
-import {
-    type BasePatreonQuery,
-    buildQuery,
-    type QueryRequestOptions,
-} from '../../rest/v2/query'
+/* eslint-disable jsdoc/require-returns */
+import { RequestPayload } from '../../payloads/v2/internals/request'
 
 import type {
     RelationshipFields,
+    RelationshipFieldToFieldType,
     RelationshipMap,
 } from './relationships'
 
 import * as SchemaResourcesData from './generated/schemas'
 
 import { Type } from './item'
+
+type ValueOrArray<T> = T | T[]
+
+type PaginationQuerySort =
+    | string
+    | { key: string, descending?: boolean }
+
+/** @deprecated */
+export type PaginationQuery = {
+    cursor?: string
+    count?: number
+    sort?: ValueOrArray<PaginationQuerySort>
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface QueryRequestOptions extends PaginationQuery {
+
+}
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function getResource <T extends Type>(t: T) {
@@ -28,7 +44,7 @@ function getResource <T extends Type>(t: T) {
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function createCompleteQueryOptions <
+function createCompleteQueryOptions <
     T extends Type
 >(t: T) {
     const data = getResource(t)
@@ -46,37 +62,247 @@ export function createCompleteQueryOptions <
     }
 }
 
-export const buildCompleteQuery = {
-    campaign: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Campaign)
-        return buildQuery.campaign(include)(attributes, options)
-    },
-    campaignMembers: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Member)
-        return buildQuery.campaignMembers(include)(attributes, options)
-    },
-    campaignPosts: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Post)
-        return buildQuery.campaignPosts(include)(attributes, options)
-    },
-    campaigns: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Campaign)
-        return buildQuery.campaigns(include)(attributes, options)
-    },
-    identity: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.User)
-        return buildQuery.identity(include)(attributes, options)
-    },
-    member: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Member)
-        return buildQuery.member(include)(attributes, options)
-    },
-    post: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Post)
-        return buildQuery.post(include)(attributes, options)
-    },
-    webhooks: (options?: QueryRequestOptions) => {
-        const { attributes, include } = createCompleteQueryOptions(Type.Webhook)
-        return buildQuery.webhooks(include)(attributes, options)
-    },
-} satisfies Record<keyof typeof buildQuery, (options?: QueryRequestOptions) => BasePatreonQuery>
+export class QueryBuilder<
+    T extends Type,
+    Listing extends boolean,
+    Relationships extends RelationshipFields<T> = never,
+    Attributes extends RelationshipMap<T, Relationships> = never
+> {
+    /**
+     * The options for the request, e.g. pagination and sorting.
+     */
+    public requestOptions: QueryRequestOptions | undefined = undefined
+
+    private _relationships: Relationships[] = []
+    private _attributes: Attributes = {} as Attributes
+    private schema: ReturnType<typeof getResource<T>>
+
+    /**
+     * The type to use for extracting the payload type.
+     *
+     * Do not use as the actual payload as it is an empty string and will not contain the actual payload.
+     */
+    public readonly _payload_type: RequestPayload<T, Relationships, Attributes, Listing> = <never>''
+
+    public constructor (
+        /**
+         * The main resource that this query is for.
+         */
+        public readonly resource: T,
+
+        /**
+         * Whether this query is for listing the {@link resource} or only for for getting a single item of the resource.
+         */
+        // @ts-expect-error unused prop
+        private readonly isListing: Listing,
+    ) {
+        this.schema = getResource(resource)
+    }
+
+    protected getRelationshipResourceName <R extends RelationshipFields<T>> (
+        relationship: R,
+    ): RelationshipFieldToFieldType<T, R> {
+        const relation = this.schema.relationships.find(r => r.name === relationship)
+        if (!relation) throw new Error(`Unable to find relationship '${relationship}' on resource '${this.resource}'`)
+
+        return relation.resource as RelationshipFieldToFieldType<T, R>
+    }
+
+    /**
+     * The raw search params.
+     * Use {@link query} for the stringified params.
+     */
+    public get params (): URLSearchParams {
+        return new URLSearchParams({
+            ...(this._relationships.length > 0 ? { include: this._relationships.join(',') } : {}),
+            ...Object
+                .keys(this._attributes)
+                .reduce((params, key) => ({ ...params, [`fields[${key}]`]: this._attributes[key].join(',') }), {}),
+            ...QueryBuilder.resolveQueryOptions(this.requestOptions),
+        })
+    }
+
+    /**
+     * The actual encoded query string.
+     * @example `'?fields%5Buser%5D=url%2Cname'`
+     */
+    public get query (): string {
+        return QueryBuilder.toQuery(this.params)
+    }
+
+    public get attributes (): Attributes {
+        return this._attributes
+    }
+
+    public get relationships (): Relationships[] {
+        return this._relationships
+    }
+
+    public attributesFor<R extends Relationships> (relationship: R) {
+        return this._attributes[relationship]
+    }
+
+    public setRequestOptions (options: QueryRequestOptions): this {
+        this.requestOptions = options
+
+        return this
+    }
+
+    public includeAllRelationships () {
+        const { include } = QueryBuilder.createCompleteOptions(this.resource)
+
+        this._relationships = include
+
+        return this as QueryBuilder<T, Listing, RelationshipFields<T>, Attributes>
+    }
+
+    public includeAll () {
+        const { include, attributes } = QueryBuilder.createCompleteOptions(this.resource)
+
+        this._relationships = include
+        this._attributes = attributes as Attributes
+
+        return this as QueryBuilder<T, Listing, RelationshipFields<T>, Required<RelationshipMap<T, RelationshipFields<T>>>>
+    }
+
+    public setAttributes <A extends RelationshipMap<T, Relationships>>(attributes: A) {
+        this._attributes = {
+            ...this._attributes,
+            ...attributes,
+        }
+
+        return this as unknown as QueryBuilder<T, Listing, Relationships, A>
+    }
+
+    public addRelationships<R extends RelationshipFields<T>>(relationships: R[]) {
+        this._relationships.push(...relationships)
+
+        return this as unknown as QueryBuilder<T, Listing, R | Relationships, Attributes>
+    }
+
+    public setRelationships<R extends RelationshipFields<T>>(relationships: R[]) {
+        this._relationships = relationships
+
+        return this as unknown as QueryBuilder<T, Listing, R, Attributes>
+    }
+
+    public addRelationshipAttributes <
+        R extends Relationships,
+        A extends NonNullable<Pick<RelationshipMap<T, R>, RelationshipFieldToFieldType<T, R>>[RelationshipFieldToFieldType<T, R>]>
+    >(relationship: R, attributes: A) {
+        if (!this._relationships.includes(relationship)) {
+            this._relationships.push(relationship)
+        }
+
+        const relationResource = this.getRelationshipResourceName(relationship)
+
+        // @ts-expect-error Weird TS typing stuff
+        this._attributes[relationResource] ??= [] as (typeof attributes)[number][]
+        // @ts-expect-error Weird TS typing stuff
+        this._attributes[relationResource]?.push(attributes)
+
+        return this as unknown as QueryBuilder<T, Listing, Relationships | R, (Attributes extends never ? object : Attributes) & {
+            [Item in `${RelationshipFieldToFieldType<T, R>}`]: A
+        }>
+    }
+
+    public setRelationshipAttributes <
+        R extends Relationships,
+        A extends NonNullable<Pick<RelationshipMap<T, R>, R>>[R]
+    >(relationship: R, attributes: A) {
+        if (!this._relationships.includes(relationship)) {
+            this._relationships.push(relationship)
+        }
+
+        // @ts-expect-error Weird TS typing stuff
+        this._attributes[relationship] = attributes
+
+        return this as unknown as QueryBuilder<T, Listing, Relationships | R, Omit<Attributes, RelationshipFieldToFieldType<T, R>> & { [K in RelationshipFieldToFieldType<T, R>]: A }>
+    }
+
+    public static get campaign () {
+        return new QueryBuilder(Type.Campaign, false)
+    }
+
+    public static get campaignMembers () {
+        return new QueryBuilder(Type.Member, true)
+    }
+
+    public static get campaignPosts () {
+        return new QueryBuilder(Type.Post, true)
+    }
+
+    public static get campaigns () {
+        return new QueryBuilder(Type.Campaign, true)
+    }
+
+    public static get identity () {
+        return new QueryBuilder(Type.User, false)
+    }
+
+    public static get member () {
+        return new QueryBuilder(Type.Member, false)
+    }
+
+    public static get post () {
+        return new QueryBuilder(Type.Post, false)
+    }
+
+    public static get webhooks () {
+        return new QueryBuilder(Type.Webhook, true)
+    }
+
+    public static createCompleteOptions <T extends Type>(resource: T) {
+        return createCompleteQueryOptions<T>(resource)
+    }
+
+    public static createFunctionBuilder <T extends Type, Listing extends boolean> (builder: QueryBuilder<T, Listing>) {
+        return function <Includes extends RelationshipFields<`${T}`> = never>(include?: Includes[]) {
+            return function <
+                Attributes extends RelationshipMap<T, Includes>,
+            >(attributes?: Attributes, options?: QueryRequestOptions): QueryBuilder<T, Listing, Includes, Attributes> {
+                if (options != undefined) {
+                    builder.setRequestOptions(options)
+                }
+
+                return builder
+                    .setRelationships<Includes>(include ?? [])
+                    .setAttributes<Attributes>((attributes ?? {}) as Attributes)
+            }
+        }
+    }
+
+    protected static toQuery(params: URLSearchParams): string {
+        return params.size > 0 ? '?' + params.toString() : ''
+    }
+
+    /**
+     * Helper function to convert query options to parameter options
+     * @param options the request options
+     * @returns the parameters options
+     */
+    protected static resolveQueryOptions(options?: QueryRequestOptions): Record<string, string> {
+        const params: Record<string, string> = {}
+
+        if (options?.count != undefined) params['page[count]'] = options.count.toString()
+        if (options?.cursor != undefined) params['page[cursor]'] = options.cursor
+        if (options?.sort != undefined) params['sort'] = this.resolveSortOptions(options.sort)
+
+        return params
+    }
+
+    /**
+     * Helper function to convert pagination sort options to a parameter
+     * @param options the sort options
+     * @returns the parameter to include in the query
+     */
+    protected static resolveSortOptions(options: ValueOrArray<PaginationQuerySort>): string {
+        return (Array.isArray(options) ? options : [options])
+            .map(option => {
+                return typeof option === 'string'
+                    ? option
+                    : (option.descending ? `-${option.key}` : option.key)
+            })
+            .join(',')
+    }
+}

--- a/src/scripts/v2/schemas.ts
+++ b/src/scripts/v2/schemas.ts
@@ -31,11 +31,11 @@ export async function syncResourceSchemas () {
                 initializer: writer => {
                     writer.block(() => {
                         writer.indent()
-                        writer.write('resource: \'' + type + '\',')
+                        writer.write('resource: <const>\'' + type + '\',')
                         writer.newLine()
 
                         writer.indent()
-                        writer.write('properties: [')
+                        writer.write('properties: <const>[')
                         for (const name of properties) {
                             writer.newLine()
                             writer.indent(2)
@@ -46,7 +46,7 @@ export async function syncResourceSchemas () {
 
                         writer.newLine()
                         writer.indent()
-                        writer.write('relationships: [')
+                        writer.write('relationships: <const>[')
                         for (const relation of relationships[type]) {
                             writer.newLine()
                             writer.indent(2)


### PR DESCRIPTION
closes #106 

<!-- 
Before creating a pull request:
- open an issue
- make sure all the tests (and coverage) pass
- run linter and typescript compiler
 -->

## Changes this PR makes

Instead of including all properties manually, there's now a builder that will improve the experience of making queries. Together with the simplified responses it will finally abstract all of Patreon's JSON:API features 🥳 

```ts
const oldQuery = buildQuery.campaign(['tiers'])({ tier: ['some property'] })

const newQuery = QueryBuilder.campaign
       .addRelationshipAttributes('tiers', ['some  property'])
```
With the addition of the following builder methods to include properties without listing them:

```ts
QueryBuilder.campaign.includeAllRelationships() // only sets the `include` field with all available relationships
QueryBuilder.campaign.includeAll() // get everything from the attributes and the relationship attributes

const response = await client.fetchCampaigns(QueryBuilder.campaigns.includeAll())
```

And methods to easily add / overwrite attributes (for a relationship).

Plus, if you want to make a query for fetching images (if that is an endpoint in the future) and this library has not been updated yet you can easily make a query for that endpoint (will need to augment/patch some relationship types to get ts to work properly though):
```ts
const mediaQuery = new QueryBuilder(Type.Media, true)
```

Or if you want to customize the queries to reuse or validate or  whatever you want:

```ts
class CustomCampaignQuery extends QueryBuilder<Type.Campaign, false> {
     public constructor () {
           super(Type.Campaign, false)
     }
}
```

But having it as a builder also allows people to extend their own queries easily and add relationships for only query while using the attributes from the base query
