### PR TITLE
fix(rest): only warn/throw when scopes are missing

### DIFF
--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -178,6 +178,8 @@ export class PatreonOauthClient {
         const requiredScopes = getRequiredScopes.forPath(path, query)
         const missingScopes = requiredScopes.filter(scope => !this.options.scopes?.includes(scope))
 
+        if (missingScopes.length === 0) return
+
         const msg = `Missing oauth scopes for ${path}: "${missingScopes.join('", "')}"`
         if (validate === 'warn') console.log(msg)
         else throw new Error(msg)


### PR DESCRIPTION
The current behaviour of `validateScopes` results in a warning or error even if all the required scopes are present.

## Changes this PR makes

Only log the warning or throw the error if any of the required scopes are missing.