### PR TITLE
fix(oauth): space-separated `scope` param in authorize URL

### DIFF
--- a/src/rest/v2/oauth2/client.ts
+++ b/src/rest/v2/oauth2/client.ts
@@ -340,7 +340,7 @@ export class PatreonOauthClient {
         const scopes = options?.scopes ?? this.options.scopes
 
         if (state) params.set('state', state)
-        if (scopes?.length) params.set('scopes', scopes.join(','))
+        if (scopes?.length) params.set('scope', scopes.join(' '))
 
         return this.options.authorizationUri + '?' + params.toString()
     }


### PR DESCRIPTION
## Changes this PR makes

Instead of a comma-separated `scopes` param, the [authorize URL](https://docs.patreon.com/#step-2-making-the-log-in-button) expects a _space-separated_ `scope` param.

### Note

I didn't notice this bug when testing my own campaign because all scopes are granted to the creator of the API client. However, when another creator tries to authorize they only get the default `identity` scope because the `scopes` param is invalid (and ignored).