### PR TITLE
feat(rest): deprecate `buildQuery`

### DIFF
--- a/examples/nodejs-cjs/index.js
+++ b/examples/nodejs-cjs/index.js
@@ -2,8 +2,8 @@
 /* eslint-disable no-undef */
 
 const {
-    buildQuery,
     PatreonCreatorClient,
+    QueryBuilder,
 } = require('patreon-api.ts')
 
 const client = new PatreonCreatorClient({
@@ -25,11 +25,8 @@ const client = new PatreonCreatorClient({
     }
 })
 
-const query = buildQuery.campaigns(['creator'])({
-    user: ['social_connections']
-})
-
-
+const query = QueryBuilder.campaigns
+    .addRelationshipAttributes('creator', ['social_connections'])
 
 client.fetchCampaigns(query)
     .then(payload => console.log(JSON.stringify(payload.included[0].attributes.social_connections, null, 4)))

--- a/src/rest/v2/query.ts
+++ b/src/rest/v2/query.ts
@@ -56,6 +56,9 @@ export function createQuery<Q extends BasePatreonQueryType<Type, boolean>>(param
     return QueryBuilder.fromParams<Q>(params)
 }
 
+/**
+ * @deprecated use QueryBuilder.{property}.build instead of buildQuery.
+ */
 export const buildQuery = {
     identity: QueryBuilder.createFunctionBuilder(QueryBuilder.identity),
     campaign: QueryBuilder.createFunctionBuilder(QueryBuilder.campaign),

--- a/src/rest/v2/routes.ts
+++ b/src/rest/v2/routes.ts
@@ -1,6 +1,7 @@
 import { APIVersion } from './version'
 
 export const RouteBases = {
+    /** @deprecated This is not used in the API documentation */
     api: `https://patreon.com/api/v${APIVersion}`,
     oauth2: `https://patreon.com/api/oauth2/v${APIVersion}`,
 } as const

--- a/src/schemas/v2/query.ts
+++ b/src/schemas/v2/query.ts
@@ -325,10 +325,16 @@ export class QueryBuilder<
         return createCompleteQueryOptions<T>(resource)
     }
 
+    /** @deprecated This will be removed some time after buildQuery has been removed */
+    public get build () {
+        return QueryBuilder.createFunctionBuilder(this)
+    }
+
     /**
      * Create a function builder from a query builder.
      *
      * This is to support the legacy `buildQuery`.
+     * @deprecated
      * @param builder The query builder to convert
      */
     public static createFunctionBuilder <T extends Type, Listing extends boolean> (builder: QueryBuilder<T, Listing>) {


### PR DESCRIPTION
closes -

<!-- 
Before creating a pull request:
- open an issue
- make sure all the tests (and coverage) pass
- run linter and typescript compiler
 -->

## Changes this PR makes

feat(rest): deprecate QueryBuilder#createFunctionBuilder

feat(rest): deprecate RouteBases.api
